### PR TITLE
Fix  LT-18550 FW Backup file invalid when restoring in FLEx 9.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,31 @@
+LCModel Library
+===============
+
+Description
+-----------
+
+The library for the SIL Language and Culture Model.
+The liblcm library is the core FieldWorks model for linguistic analyses of languages. Tools in this library provide the ability to store and interact with language and culture data, including anthropological, text corpus, and linguistics data.
+
+Instructions
+------------
+
+1. Install Required Software
+- git
+- Visual Studio 2015 or MonoDevelop
+
+2. Clone the liblcm repository
+- Open a terminal (or git bash Windows) and cd into a desired directory.
+- Run `git clone https://github.com/sillsdev/liblcm.git`
+
+3. Build liblcm
+cd into the directory of the cloned liblcm repository.
+
+**On Windows**
+- Run `build.cmd` to build the liblcm library.
+
+**On Linux**
+- Run `build.sh` to build the liblcm library.
+
+By default, this will build liblcm in the Debug configuration.
+To build with a different configuration, use `build.(cmd|sh) (Debug|Release)`

--- a/src/SIL.LCModel/DomainServices/BackupRestore/BackupFileSettings.cs
+++ b/src/SIL.LCModel/DomainServices/BackupRestore/BackupFileSettings.cs
@@ -550,7 +550,6 @@ namespace SIL.LCModel.DomainServices.BackupRestore
 		/// <summary>
 		/// Completes initialization after deserializing the backup settings xml
 		/// </summary>
-		/// <param name="settings"></param>
 		private void CompleteInitialization(BackupFileSettings settings)
 		{
 			m_backupTime = settings.BackupTime;
@@ -582,9 +581,9 @@ namespace SIL.LCModel.DomainServices.BackupRestore
 				Stream zipStream = zf.GetInputStream(zipEntry);
 				XDocument xDoc = XDocument.Load(zipStream);
 				string backupXml = xDoc.ToString();
-				string xmlNamespace = @"\s+\bxmlns\b="".+\.\bBackupRestore\b\""\s+";
+				string xmlNamespace = @"\s+xmlns="".+\.BackupRestore""";
 				string expectedNamespace =
-					@" xmlns=""http://schemas.datacontract.org/2004/07/SIL.LCModel.DomainServices.BackupRestore"" ";
+					@" xmlns=""http://schemas.datacontract.org/2004/07/SIL.LCModel.DomainServices.BackupRestore""";
 				backupXml = Regex.Replace(backupXml, xmlNamespace, expectedNamespace);
 				BackupFileSettings settings = CreateFromXml(backupXml);
 				CompleteInitialization(settings);


### PR DESCRIPTION
The namespace expected from the backup settings xml in the .fwbackup archive is set to SIL.LCModel.DomainServices.BackupRestore. Any backup settings file created before FLEx 9.0 will be treated with the updated namespace.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/liblcm/8)
<!-- Reviewable:end -->
