### PR TITLE
Enable LCModel to be built using pre-existing files

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,4 +28,13 @@ Instructions
 - Run `build.sh` to build the liblcm library.
 
 By default, this will build liblcm in the Debug configuration.
-To build with a different configuration, use `build.(cmd|sh) (Debug|Release)`
+To build with a different configuration, use:
+
+    build.(cmd|sh) (Debug|Release)
+
+Debugging
+---------
+
+The LCModel library depends on multiple libpalaso files that are downloaded automatically by triggering the build script. The option to build liblcm using locally built dependencies is also available to assist with debugging. Copy all of the relevent files from the libpalaso output folder into the lib/downloads folder in liblcm, then build with the command:
+
+    build.(cmd|sh) Debug Build True

--- a/build.cmd
+++ b/build.cmd
@@ -12,4 +12,10 @@ if "%2"=="" (
     SET TARGET=%2
 )
 
-msbuild /t:%TARGET% /p:Configuration=%CONFIG% /p:Platform=x86 LCM.sln
+if "%3"=="" (
+	SET FILESAVAILABLE=False
+) else (
+	SET FILESAVAILABLE=%3
+)
+
+msbuild /t:%TARGET% /p:Configuration=%CONFIG% /p:Platform=x86 /p:UseLocalFiles=%FILESAVAILABLE% LCM.sln

--- a/build.sh
+++ b/build.sh
@@ -12,5 +12,10 @@ else
     TARGET=$2
 fi
 
+if [ -z "$3" ] ; then
+	FILESAVAILABLE=False
+else
+	FILESAVAILABLE=$3
+
 . environ
-xbuild /t:$TARGET /p:Configuration=$CONFIG /p:Platform=x86 LCM.sln
+xbuild /t:$TARGET /p:Configuration=$CONFIG /p:Platform=x86 /p:UseLocalFiles=$FILESAVAILABLE LCM.sln

--- a/src/SIL.LCModel.Utils/BuildInclude.targets
+++ b/src/SIL.LCModel.Utils/BuildInclude.targets
@@ -18,6 +18,6 @@
 		<Delete Files="$(JobsFile)" ContinueOnError="true" />
 	</Target>
 
-	<Target Name="BeforeBuild" DependsOnTargets="DownloadDependencies">
+	<Target Name="BeforeBuild" DependsOnTargets="DownloadDependencies" Condition="'$(UseLocalFiles)'!='True'">
 	</Target>
 </Project>


### PR DESCRIPTION
*dependencies can be copied into the lib folder before build.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/liblcm/13)
<!-- Reviewable:end -->
