### PR TITLE
Choose available libhunspell version at runtime

### DIFF
--- a/src/SIL.LCModel.Core/App.config
+++ b/src/SIL.LCModel.Core/App.config
@@ -2,14 +2,4 @@
 <configuration>
   <dllmap dll="icuuc54.dll" target="libicuuc.so.54" />
   <dllmap dll="icuin54.dll" target="libicui18n.so.54" />
-  <dllmap dll="libhunspell">
-    <dllentry dll="libhunspell.so" name="hunspell_initialize" target="Hunspell_create" />
-    <dllentry dll="libhunspell.so" name="hunspell_uninitialize" target="Hunspell_destroy" />
-    <dllentry dll="libhunspell.so" name="hunspell_spell" target="Hunspell_spell" />
-    <dllentry dll="libhunspell.so" name="hunspell_add" target="Hunspell_add" />
-    <dllentry dll="libhunspell.so" name="hunspell_add_with_affix" target="Hunspell_add_with_affix" />
-    <dllentry dll="libhunspell.so" name="hunspell_remove" target="Hunspell_remove" />
-    <dllentry dll="libhunspell.so" name="hunspell_suggest" target="Hunspell_suggest" />
-    <dllentry dll="libhunspell.so" name="hunspell_free_list" target="Hunspell_free_list" />
-  </dllmap>
 </configuration>


### PR DESCRIPTION
* To support Ubuntu 18.04 (libhunspell 1.6) at the same time as 16.04
and 14.04 (libhunspell 1.3).
* Also falls back on libhunspell.so, provided by package libhunspell-
dev.
* Fixes crash LT-18708.
* There are many ways to implement this. If our use of libhunspell
grows in complexity, another way may be more suitable.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/liblcm/21)
<!-- Reviewable:end -->
