### PR TITLE
Fix: LT-18697 Crash after added Bible texts from Choose Texts

### DIFF
--- a/src/SIL.LCModel/DomainServices/ITextUtils.cs
+++ b/src/SIL.LCModel/DomainServices/ITextUtils.cs
@@ -767,6 +767,10 @@ namespace SIL.LCModel.DomainServices
 					}
 				}
 				tssWord = m_wordMaker.NextWord(out ichMin, out ichLim);
+				if (tssWord == null)
+				{
+					tssFirstWordOfNextSegment = tssWord;
+				}
 			} while (true);
 			return formsInSegment;
 		}


### PR DESCRIPTION
 * Reset the tssFirstWordOfNextSegment to Null,
   When Segment doesn't have no more words.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/liblcm/22)
<!-- Reviewable:end -->
