### PR TITLE
Fix LT-18771: Undoing the deletion Duplicates reference

### DIFF
--- a/src/SIL.LCModel/DomainImpl/OverridesLing_Lex.cs
+++ b/src/SIL.LCModel/DomainImpl/OverridesLing_Lex.cs
@@ -3970,6 +3970,8 @@ namespace SIL.LCModel.DomainImpl
 			{
 				((ICmObjectRepositoryInternal) Services.ObjectRepository).EnsureCompleteIncomingRefsFrom(
 					LexReferenceTags.kflidTargets);
+				//On Undo, possibly chances of duplicates of LexReference. Hence we removed the invalid references.
+				RemoveDuplicateRefs();
 				foreach (var item in m_incomingRefs)
 				{
 					var sequence = item as LcmReferenceSequence<ICmObject>;
@@ -3978,6 +3980,29 @@ namespace SIL.LCModel.DomainImpl
 					if (sequence.Flid == LexReferenceTags.kflidTargets)
 						yield return sequence.MainObject as ILexReference;
 				}
+			}
+		}
+
+		/// <summary>
+		/// LT-18771 - Method to remove the duplicated references occurs on Undo process, 
+		/// the first one of duplicated item becomes invalid. So we removed here.
+		/// </summary>
+		private void RemoveDuplicateRefs()
+		{
+			int index = 0;
+			var refsList = new Dictionary<int, int>();
+			foreach (var item in m_incomingRefs)
+			{
+				var sequence = item as LcmReferenceSequence<ICmObject>;
+				if (!refsList.ContainsKey(sequence.MainObject.Hvo))
+					refsList.Add(sequence.MainObject.Hvo, index);
+				else
+				{
+					var prevRef = m_incomingRefs.ElementAt(refsList[sequence.MainObject.Hvo]);
+					m_incomingRefs.Remove(prevRef);
+					refsList[sequence.MainObject.Hvo] = index;
+				}
+				index++;
 			}
 		}
 

--- a/src/SIL.LCModel/DomainImpl/OverridesLing_Lex.cs
+++ b/src/SIL.LCModel/DomainImpl/OverridesLing_Lex.cs
@@ -3990,6 +3990,7 @@ namespace SIL.LCModel.DomainImpl
 		private void RemoveDuplicateRefs()
 		{
 			int index = 0;
+			List<IReferenceSource> refsToRemove = new List<IReferenceSource>();
 			var refsList = new Dictionary<int, int>();
 			foreach (var item in m_incomingRefs)
 			{
@@ -3999,10 +4000,16 @@ namespace SIL.LCModel.DomainImpl
 				else
 				{
 					var prevRef = m_incomingRefs.ElementAt(refsList[sequence.MainObject.Hvo]);
-					m_incomingRefs.Remove(prevRef);
+					refsToRemove.Add(prevRef);
 					refsList[sequence.MainObject.Hvo] = index;
 				}
 				index++;
+			}
+
+			if (refsToRemove.Count > 0)
+			{
+				foreach (var refItem in refsToRemove)
+					m_incomingRefs.Remove(refItem);
 			}
 		}
 

--- a/tests/SIL.LCModel.Tests/Infrastructure/Impl/VirtualPropertyPropChangedTests.cs
+++ b/tests/SIL.LCModel.Tests/Infrastructure/Impl/VirtualPropertyPropChangedTests.cs
@@ -890,22 +890,10 @@ namespace SIL.LCModel.Infrastructure.Impl
 				{
 					lexRef.TargetsRS.Add(sense2);
 				});
-			// The numbers added here are strange, reflecting that the update code doesn't know the old
-			// value of the virtual property and pretends it was previously empty. Thus for example, because
-			// lexRef now points at sense2 twice, there are now two backrefs from sense2 to lexRef.
-			// The PropChanged is sent as if both were new.
-			CheckChange(LexSenseTags.kClassId, sense2, "LexSenseReferences", 0, 2, 0,
-						"Adding second sense from LexReference should update LexSenseReferences of added sense");
 
-			PrepareToTrackPropChanged();
-			UndoableUnitOfWorkHelper.Do("undo remove target", "redo", m_actionHandler,
-				() =>
-				{
-					lexRef.TargetsRS.Remove(sense2);
-				});
-			// We're now back to one backref from sense2 to lexRef. The PropChanged can only show this as an insertion!
+			//Previously two references were added this error has been fixed
 			CheckChange(LexSenseTags.kClassId, sense2, "LexSenseReferences", 0, 1, 0,
-						"Removing one of two copies of sense from LexReference should update LexSenseReferences of removed sense");
+						"Adding second sense from LexReference should update LexSenseReferences of added sense");
 
 			PrepareToTrackPropChanged();
 			UndoableUnitOfWorkHelper.Do("undo remove target", "redo", m_actionHandler,


### PR DESCRIPTION
*Included method to delete the first item of duplication
*Found first duplicated item is invalid entry after Undo

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/liblcm/24)
<!-- Reviewable:end -->
