### PR TITLE
Fix LT-18781:Crash appears on "Lexicon Edit" pane when changing category

### DIFF
--- a/src/SIL.LCModel/DomainImpl/OverridesLing_MoClasses.cs
+++ b/src/SIL.LCModel/DomainImpl/OverridesLing_MoClasses.cs
@@ -1665,7 +1665,7 @@ namespace SIL.LCModel.DomainImpl
 				if (InflFeatsOA != srcMsa.InflFeatsOA)
 					CopyObject<IFsFeatStruc>.CloneLcmObject(srcMsa.InflFeatsOA, newMsa => InflFeatsOA = newMsa);
 				RemoveInvalidFeatureSpecs(PartOfSpeechRA, InflFeatsOA);
-				if (InflFeatsOA.IsEmpty)
+				if (InflFeatsOA.IsEmpty || InflFeatsOA.FeatureSpecsOC.Count == 0)
 					InflFeatsOA = null;
 			}
 		}


### PR DESCRIPTION
*Added one more condition to set null
*InflFeatsOA also be null when invalid features.
*Added test case OnRefresh_SetNullInflFeatsOAWhenInvalidFeature

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/liblcm/27)
<!-- Reviewable:end -->
