### PR TITLE
Fix: LT-18813 Crash on LexEdit Pane on navigate from Texts&Words

### DIFF
--- a/src/SIL.LCModel/DomainImpl/OverridesLing_Lex.cs
+++ b/src/SIL.LCModel/DomainImpl/OverridesLing_Lex.cs
@@ -3997,6 +3997,8 @@ namespace SIL.LCModel.DomainImpl
 			foreach (var item in m_incomingRefs)
 			{
 				var sequence = item as LcmReferenceSequence<ICmObject>;
+				if (sequence == null)
+					continue;
 				if (!refsList.ContainsKey(sequence.MainObject.Hvo))
 					refsList.Add(sequence.MainObject.Hvo, index);
 				else


### PR DESCRIPTION
* Have checked whether sequence is null
  in RemoveDuplicateRefs() method of LexSense

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/liblcm/28)
<!-- Reviewable:end -->
