### PR TITLE
Allow using a Tss as a Morph in ParagraphParserTests

### DIFF
--- a/tests/SIL.LCModel.Tests/DomainServices/ParagraphParserTests.cs
+++ b/tests/SIL.LCModel.Tests/DomainServices/ParagraphParserTests.cs
@@ -687,6 +687,11 @@ namespace SIL.LCModel.DomainServices
 						// just set the Form.
 						wmb.Form.SetVernacularDefaultWritingSystem((string)morphForm);
 					}
+					else if (morphForm is ITsString)
+					{
+						var tssMf = (ITsString)morphForm;
+						wmb.Form.set_String(TsStringUtils.GetWsAtOffset(tssMf, 0), tssMf);
+					}
 					else if (morphForm is IMoForm)
 					{
 						wmb.MorphRA = morphForm as IMoForm;


### PR DESCRIPTION
Also, more sensible method order in WritingSystemServices

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/liblcm/31)
<!-- Reviewable:end -->
