### PR TITLE
Remove IReversalIndexEntry.ReferringSenses

### DIFF
--- a/src/SIL.LCModel/DomainImpl/OverridesLing_Lex.cs
+++ b/src/SIL.LCModel/DomainImpl/OverridesLing_Lex.cs
@@ -6532,13 +6532,6 @@ namespace SIL.LCModel.DomainImpl
 			}
 		}
 
-		public IEnumerable<ILexSense> ReferringSenses
-		{
-			get {
-				return SensesRS;
-			}
-		}
-
 		/// <summary>
 		/// Get the set of senses that refer to this reversal entry and sort them
 		/// </summary>

--- a/src/SIL.LCModel/Infrastructure/Impl/RepositoryAdditions.cs
+++ b/src/SIL.LCModel/Infrastructure/Impl/RepositoryAdditions.cs
@@ -1628,7 +1628,7 @@ namespace SIL.LCModel.Infrastructure.Impl
 		/// </summary>
 		public IEnumerable<ILexSense> InstancesWithReversalEntry(IReversalIndexEntry entry)
 		{
-			return (entry as ReversalIndexEntry).ReferringSenses;
+			return (entry as ReversalIndexEntry).SensesRS;
 		}
 	}
 	#endregion

--- a/src/SIL.LCModel/InterfaceAdditions.cs
+++ b/src/SIL.LCModel/InterfaceAdditions.cs
@@ -1987,11 +1987,6 @@ namespace SIL.LCModel
 		}
 
 		/// <summary>
-		/// Get the set of senses that refer to this reversal entry.
-		/// </summary>
-		IEnumerable<ILexSense> ReferringSenses { get; }
-
-		/// <summary>
 		///
 		/// </summary>
 		IReversalIndex ReversalIndex

--- a/tests/SIL.LCModel.Core.Tests/SpellChecking/SpellingHelperTests.cs
+++ b/tests/SIL.LCModel.Core.Tests/SpellChecking/SpellingHelperTests.cs
@@ -301,8 +301,10 @@ namespace SIL.LCModel.Core.SpellChecking
 			DirectoryUtilities.DeleteDirectoryRobust(inputFolder);
 			Directory.CreateDirectory(outputFolder);
 			Directory.CreateDirectory(inputFolder);
+			// ReSharper disable LocalizableElement
 			File.AppendAllText(Path.Combine(inputFolder, "test.dic"), "nil");
 			File.AppendAllText(Path.Combine(inputFolder, "test.exc"), "nil");
+			// ReSharper restore LocalizableElement
 			// SUT
 			Assert.DoesNotThrow(()=>SpellingHelper.AddAnySpellingExceptionsFromBackup(inputFolder, outputFolder));
 			// Verify that the correct files were copied

--- a/tests/SIL.LCModel.Tests/Infrastructure/Impl/VirtualPropertyPropChangedTests.cs
+++ b/tests/SIL.LCModel.Tests/Infrastructure/Impl/VirtualPropertyPropChangedTests.cs
@@ -244,7 +244,7 @@ namespace SIL.LCModel.Infrastructure.Impl
 			var sense = entry.SensesOS.First();
 
 			Assert.IsNotNull(reversal, "the expected reversal object was created");
-			Assert.AreEqual(0, reversal.ReferringSenses.Count(), "nothing should refer to the reversal entry initially");
+			Assert.AreEqual(0, reversal.SensesRS.Count(), "nothing should refer to the reversal entry initially");
 
 
 			PrepareToTrackPropChanged();


### PR DESCRIPTION
ReferringSenses is a no-longer-needed alias to SensesRS

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/liblcm/35)
<!-- Reviewable:end -->
