### PR TITLE
Fix: LT-18930 Crash appears on reversal indexes pane

### DIFF
--- a/src/SIL.LCModel/DomainImpl/OverridesLing_MoClasses.cs
+++ b/src/SIL.LCModel/DomainImpl/OverridesLing_MoClasses.cs
@@ -3564,7 +3564,7 @@ namespace SIL.LCModel.DomainImpl
 		///<summary>Needed only for Allomorph types; placeholder to keep the compiler happy</summary>
 		public virtual ILcmReferenceCollection<IPhEnvironment> AllomorphEnvironments
 		{
-			get { return Cache.ServiceLocator.GetInstance<ILcmReferenceCollection<IPhEnvironment>>(); }
+			get { return null; }
 		}
 	}
 


### PR DESCRIPTION
 * Changed the code to set to null.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/liblcm/43)
<!-- Reviewable:end -->
