### PR TITLE
Fix LT-19053: Crash deleting inflection classes

### DIFF
--- a/src/SIL.LCModel/DomainImpl/OverridesLing_Lex.cs
+++ b/src/SIL.LCModel/DomainImpl/OverridesLing_Lex.cs
@@ -6828,7 +6828,7 @@ namespace SIL.LCModel.DomainImpl
 			if (phonRuleFeatList != null)
 			{
 				var phonRuleFeats = phonRuleFeatList.PossibilitiesOS.Cast<IPhPhonRuleFeat>();
-				if (phonRuleFeats != null && phonRuleFeats.Count() > 0)
+				if (phonRuleFeats != null && phonRuleFeats.Count() > 0 && phonRuleFeats.Where(prf => prf.ItemRA == obj).Count() > 0)
 				{
 					var phonRuleFeat = phonRuleFeats.First(prf => prf.ItemRA == obj);
 					phonRuleFeatList.PossibilitiesOS.Remove(phonRuleFeat);


### PR DESCRIPTION
* Changed code to delete inflection class without crashing

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/liblcm/53)
<!-- Reviewable:end -->
