### PR TITLE
Update GenerateKernelCs.proj

### DIFF
--- a/src/SIL.LCModel.Core/GenerateKernelCs.proj
+++ b/src/SIL.LCModel.Core/GenerateKernelCs.proj
@@ -6,7 +6,7 @@
 	<PropertyGroup Condition="'$(OS)'=='Windows_NT'">
 		<!-- use the vswhere provided VSInstallDir and the VCToolsVersion to locate cl.exe -->
 		<!-- This assumes that the build machine is 64bit, and that it doesn't matter if we use the x86 version of cl -->
-		<PreprocessCommand>"$(VSInstallDir)\VC\Tools\MSVC\$(VCToolsVersion)\bin\Hostx64\x86\cl.exe" /E</PreprocessCommand>
+		<PreprocessCommand>"$(VSInstallDir)\VC\Tools\MSVC\$(VCToolsVersion)\bin\Hostx64\x64\cl.exe" /E</PreprocessCommand>
 	</PropertyGroup>
 	<PropertyGroup Condition="'$(OS)'=='Unix'">
 		<PreprocessCommand>gcc -E -x c</PreprocessCommand>


### PR DESCRIPTION
Correcting error caused by recent Visual Studio update.

Error: 'fatal error C1356: unable to find mspdbcore.dll'

The file no longer exists at the previous location: '$(VSInstallDir)\VC\Tools\MSVC\$(VCToolsVersion)\bin\Hostx64\x86\cl.exe'

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/liblcm/54)
<!-- Reviewable:end -->
