### PR TITLE
Changes for Text Constituent Chart Template

### DIFF
--- a/src/SIL.LCModel/Templates/NewLangProj.fwdata
+++ b/src/SIL.LCModel/Templates/NewLangProj.fwdata
@@ -5929,6 +5929,7 @@
 <AUni ws="en">ConChrtTempl</AUni>
 </Abbreviation>
 <Depth val="127" />
+<IsSorted val="true" />
 <ItemClsid val="7" />
 <Name>
 <AUni ws="en">Text Constituent Chart Templates</AUni>
@@ -5945,7 +5946,20 @@
 <DateCreated val="2008-01-11 15:08:55.380" />
 <DateModified val="2008-01-11 15:08:55.380" />
 <Name>
-<AUni ws="en">Default</AUni>
+<AUni ws="en">Default Template</AUni>
+</Name>
+<SubPossibilities>
+<objsur guid="397636f5-2994-4aee-b6f3-376ca71bddea" t="o" />
+</SubPossibilities>
+</rt>
+<rt class="CmPossibility" guid="397636f5-2994-4aee-b6f3-376ca71bddea" ownerguid="c414012a-ea5e-11de-99fc-0013722f8dec">
+<Abbreviation>
+<AUni ws="en">story</AUni>
+</Abbreviation>
+<DateCreated val="2018-05-09 13:24:02.152" />
+<DateModified val="2018-05-09 13:24:02.152" />
+<Name>
+<AUni ws="en">Story</AUni>
 </Name>
 <SubPossibilities>
 <objsur guid="c41fece2-ea5e-11de-8db3-0013722f8dec" t="o" />


### PR DESCRIPTION
  * Changed name of first template from Default to Default Template
  * Add a layer, Story, to the Default Text Constituent Chart Templates
  * Changed sorting of multiple templates from user-determined to alphabetical

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/liblcm/55)
<!-- Reviewable:end -->
