### PR TITLE
Fix: LT-16718 Crash if copy & paste used in the Sort tab

### DIFF
--- a/src/SIL.LCModel.Core/WritingSystems/WritingSystemManager.cs
+++ b/src/SIL.LCModel.Core/WritingSystems/WritingSystemManager.cs
@@ -580,7 +580,13 @@ namespace SIL.LCModel.Core.WritingSystems
 			{
 				CoreWritingSystemDefinition ws;
 				if (m_handleWSs.TryGetValue(handle, out ws))
+				{
+					if (string.IsNullOrEmpty(ws.Id))
+					{
+						return ws.LanguageTag;
+					}
 					return ws.Id;
+				}
 				return null;
 			}
 		}


### PR DESCRIPTION
 * Handled WritingSystem ID set to LanguageTag if it is empty.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/liblcm/57)
<!-- Reviewable:end -->
