### PR TITLE
Fix: LT-19199 Crash while creating a new lexical entry

### DIFF
--- a/src/SIL.LCModel/DomainImpl/OverridesLing_Lex.cs
+++ b/src/SIL.LCModel/DomainImpl/OverridesLing_Lex.cs
@@ -3298,6 +3298,17 @@ namespace SIL.LCModel.DomainImpl
 		}
 
 		/// <summary>
+		/// Remove one reference to the target object from one of your atomic reference properties.
+		/// </summary>
+		internal override void RemoveAReferenceCore(ICmObject target)
+		{
+			var flid = this.Cache.CustomProperties.Where(x => x.Value == target && x.Key.Item1 == this).Select(y => y.Key.Item2).FirstOrDefault();
+			if (flid > 0)
+				SetNonModelPropertyForSDA(flid, null, true);
+			base.RemoveAReferenceCore(target);
+		}
+
+		/// <summary>
 		/// Overrides the method, so we can also merge similar MSAs and allomorphs, after the main merge.
 		/// </summary>
 		public override void MergeObject(ICmObject objSrc, bool fLoseNoStringData)


### PR DESCRIPTION
* Added the code to remove reference

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/liblcm/64)
<!-- Reviewable:end -->
