### PR TITLE
 Allow to create picture with existing GUID

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,6 +1,27 @@
+# Copyright (c) 2018 SIL International
+# This software is licensed under the MIT license (http://opensource.org/licenses/MIT)
+
 root = true
+
+# Defaults
+[*]
+indent_style = tab
+indent_size = tab
+tab_width = 4
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = false
+max_line_length = 98
 
 [*.cs]
 indent_style = tab
-indent_size = 4
-trim_trailing_whitespace = true
+tab_width = 4
+
+# Settings Visual Studio uses for generated files
+[*.{csproj,resx,settings,vcxproj*,vdproj,xml,yml}]
+indent_style = space
+indent_size = 2
+
+# Generated file
+[*.sln]
+end_of_line = crlf

--- a/.gitignore
+++ b/.gitignore
@@ -10,9 +10,14 @@ artifacts/
 *DS_Store
 *.sln.ide
 lib/downloads/
+.idea/
+.vs/
 
 src/SIL.LCModel.Core/KernelInterfaces/Kernel.cs
 src/SIL.LCModel/Infrastructure/Impl/Generated*.cs
 src/SIL.LCModel/Generated*.cs
 src/SIL.LCModel/DomainImpl/Generated*.cs
 src/SIL.LCModel/IOC/Generated*.cs
+src/SIL.LCModel.Core/FwKernelTlb.idl
+src/SIL.LCModel.Core/FwKernelTlb.iip
+icu4c.readme.txt

--- a/src/SIL.LCModel/DomainImpl/FactoryAdditions.cs
+++ b/src/SIL.LCModel/DomainImpl/FactoryAdditions.cs
@@ -2137,6 +2137,20 @@ namespace SIL.LCModel.DomainImpl
 					return;
 			}
 		}
+
+		/// <summary>
+		/// Create a new entry with the given guid.
+		/// </summary>
+		public ICmPicture Create(Guid guid)
+		{
+			if (guid == Guid.Empty)
+				return Create();
+
+			int hvo = ((IDataReader) m_cache.ServiceLocator.GetInstance<IDataSetup>())
+				.GetNextRealHvo();
+			return new CmPicture(m_cache, hvo, guid);
+		}
+
 	}
 	#endregion
 

--- a/src/SIL.LCModel/FactoryInterfaceAdditions.cs
+++ b/src/SIL.LCModel/FactoryInterfaceAdditions.cs
@@ -845,6 +845,11 @@ namespace SIL.LCModel
 		ICmPicture Create(string sFolder, int anchorLoc, IPictureLocationBridge locationParser,
 			string sDescription, string srcFilename, string sLayoutPos, string sLocationRange,
 			string sCopyright, string sCaption,	PictureLocationRangeType locRangeType, string sScaleFactor);
+
+		/// <summary>
+		/// Create a new entry with the given guid.
+		/// </summary>
+		ICmPicture Create(Guid guid);
 	}
 
 	/// <summary>

--- a/tests/SIL.LCModel.Tests/DomainImpl/CmPictureTests.cs
+++ b/tests/SIL.LCModel.Tests/DomainImpl/CmPictureTests.cs
@@ -297,6 +297,34 @@ namespace SIL.LCModel.DomainImpl
 			m_pictureFactory.Create("CmPicture||whatever.jpg||||This is a caption||", CmFolderTags.LocalPictures);
 		}
 
+		/// <summary>
+		/// Tests creating a CmPicture from a GUID
+		/// </summary>
+		[Test]
+		public void CmPictureConstructor_FromGuid()
+		{
+			var guid = Guid.NewGuid();
+
+			// Execute
+			var picture = m_pictureFactory.Create(guid);
+
+			// Verify
+			Assert.That(picture.Guid, Is.EqualTo(guid));
+		}
+
+		/// <summary>
+		/// Tests creating a CmPicture from a empty GUID
+		/// </summary>
+		[Test]
+		public void CmPictureConstructor_FromEmptyGuid()
+		{
+			// Execute
+			var picture = m_pictureFactory.Create(Guid.Empty);
+
+			// Verify
+			Assert.That(picture.Guid, Is.Not.Null);
+		}
+
 		/// -------------------------------------------------------------------------------------
 		/// <summary>
 		/// Test ability to get the text representation of a picture.


### PR DESCRIPTION
The CmPictureFactory so far lacks the ability to create a picture from an existing GUID. However this is needed for LanguageForge S/R, so this change adds this.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/liblcm/69)
<!-- Reviewable:end -->
