### PR TITLE
Properly dispose LcmCache on exception during initialization

### DIFF
--- a/src/SIL.LCModel/LcmCache.cs
+++ b/src/SIL.LCModel/LcmCache.cs
@@ -257,23 +257,31 @@ namespace SIL.LCModel
 				|| providerType == BackendProviderType.kSharedXMLWithMemoryOnlyWsMgr);
 			LcmCache createdCache = CreateCacheInternal(projectId, ui, dirs, settings);
 
-			// Init backend data provider
-			var dataSetup = createdCache.ServiceLocator.GetInstance<IDataSetup>();
-			dataSetup.UseMemoryWritingSystemManager = useMemoryWsManager;
-			doThe(dataSetup);
-			initialize?.Invoke(createdCache);
-
-			createdCache.FullyInitializedAndReadyToRock = true;
-
-			// Set the default user ws if we know one.
-			// This is especially important because (as of 12 Feb 2008) we are not localizing
-			// the resource string in the Language DLL which controls the default UI language.
-			if (!string.IsNullOrEmpty(userWsIcuLocale))
+			try
 			{
-				ILcmServiceLocator servLoc = createdCache.ServiceLocator;
-				CoreWritingSystemDefinition wsUser;
-				servLoc.WritingSystemManager.GetOrSet(userWsIcuLocale, out wsUser);
-				servLoc.WritingSystemManager.UserWritingSystem = wsUser;
+				// Init backend data provider
+				var dataSetup = createdCache.ServiceLocator.GetInstance<IDataSetup>();
+				dataSetup.UseMemoryWritingSystemManager = useMemoryWsManager;
+				doThe(dataSetup);
+				initialize?.Invoke(createdCache);
+
+				createdCache.FullyInitializedAndReadyToRock = true;
+
+				// Set the default user ws if we know one.
+				// This is especially important because (as of 12 Feb 2008) we are not localizing
+				// the resource string in the Language DLL which controls the default UI language.
+				if (!string.IsNullOrEmpty(userWsIcuLocale))
+				{
+					ILcmServiceLocator servLoc = createdCache.ServiceLocator;
+					CoreWritingSystemDefinition wsUser;
+					servLoc.WritingSystemManager.GetOrSet(userWsIcuLocale, out wsUser);
+					servLoc.WritingSystemManager.UserWritingSystem = wsUser;
+				}
+			}
+			catch (Exception)
+			{
+				createdCache.Dispose();
+				throw;
 			}
 
 			return createdCache;


### PR DESCRIPTION
When we get an exception while we run dataSetup or initialization
after we internally created the cache, we have to dispose the cache.
The client can't do it because it gets the exception but doesn't
have access to the cache. Disposing the cache is necessary to
properly shut down the application in case of error, otherwise it
might hang.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/liblcm/71)
<!-- Reviewable:end -->
