### PR TITLE
Initialize ICU for tests

### DIFF
--- a/tests/SIL.LCModel.Core.Tests/App.config
+++ b/tests/SIL.LCModel.Core.Tests/App.config
@@ -12,7 +12,7 @@
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
         <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-11.0.0.0" newVersion="11.0.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-9.0.0.0" newVersion="9.0.0.0" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>

--- a/tests/SIL.LCModel.Core.Tests/Attributes/InitializeIcuAttribute.cs
+++ b/tests/SIL.LCModel.Core.Tests/Attributes/InitializeIcuAttribute.cs
@@ -5,10 +5,9 @@
 using System;
 using System.IO;
 using System.Reflection;
+using Icu;
 using Microsoft.Win32;
 using NUnit.Framework;
-using SIL.LCModel.Core.Text;
-using SIL.LCModel.Utils;
 
 namespace SIL.LCModel.Core.Attributes
 {
@@ -23,6 +22,8 @@ namespace SIL.LCModel.Core.Attributes
 		public override void BeforeTest(TestDetails testDetails)
 		{
 			base.BeforeTest(testDetails);
+
+			Wrapper.Init();
 
 			string dir = null;
 			if (string.IsNullOrEmpty(IcuDataPath))
@@ -62,12 +63,18 @@ namespace SIL.LCModel.Core.Attributes
 
 			try
 			{
-				Icu.InitIcuDataDir();
+				Text.Icu.InitIcuDataDir();
 			}
 			catch (Exception e)
 			{
 				Console.WriteLine(e.Message);
 			}
+		}
+
+		public override void AfterTest(TestDetails testDetails)
+		{
+			Wrapper.Cleanup();
+			base.AfterTest(testDetails);
 		}
 	}
 }

--- a/tests/SIL.LCModel.Core.Tests/SIL.LCModel.Core.Tests.csproj
+++ b/tests/SIL.LCModel.Core.Tests/SIL.LCModel.Core.Tests.csproj
@@ -66,6 +66,18 @@
     <ErrorReport>prompt</ErrorReport>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="icu.net, Version=2.3.2.0, Culture=neutral, PublicKeyToken=416fdd914afa6b66, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\icu.net.2.3.2\lib\net451\icu.net.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.DotNet.PlatformAbstractions, Version=2.0.4.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.DotNet.PlatformAbstractions.2.0.4\lib\net45\Microsoft.DotNet.PlatformAbstractions.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Extensions.DependencyModel, Version=2.0.4.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Extensions.DependencyModel.2.0.4\lib\net451\Microsoft.Extensions.DependencyModel.dll</HintPath>
+    </Reference>
+    <Reference Include="Newtonsoft.Json, Version=9.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Newtonsoft.Json.9.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
+    </Reference>
     <Reference Include="nunit.framework, Version=2.6.4.14350, Culture=neutral, PublicKeyToken=96d09a1eb7f44a77, processorArchitecture=MSIL">
       <HintPath>..\..\packages\NUnit.2.6.4\lib\nunit.framework.dll</HintPath>
       <Private>True</Private>

--- a/tests/SIL.LCModel.Core.Tests/packages.config
+++ b/tests/SIL.LCModel.Core.Tests/packages.config
@@ -1,4 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="icu.net" version="2.3.2" targetFramework="net461" />
+  <package id="Microsoft.DotNet.PlatformAbstractions" version="2.0.4" targetFramework="net461" />
+  <package id="Microsoft.Extensions.DependencyModel" version="2.0.4" targetFramework="net461" />
+  <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net461" />
   <package id="NUnit" version="2.6.4" targetFramework="net461" />
 </packages>

--- a/tests/SIL.LCModel.FixData.Tests/SIL.LCModel.FixData.Tests.csproj
+++ b/tests/SIL.LCModel.FixData.Tests/SIL.LCModel.FixData.Tests.csproj
@@ -50,6 +50,7 @@
     <Compile Include="FwDataFixerTests.cs" />
   </ItemGroup>
   <ItemGroup>
+    <None Include="app.config" />
     <None Include="packages.config" />
     <None Include="TestData\DanglingCustomListReference\Test.fwdata" />
     <None Include="TestData\DanglingCustomProperty\Test.fwdata" />

--- a/tests/SIL.LCModel.FixData.Tests/app.config
+++ b/tests/SIL.LCModel.FixData.Tests/app.config
@@ -1,0 +1,11 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-11.0.0.0" newVersion="11.0.0.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+</configuration>


### PR DESCRIPTION
This improves stability for multi-threading and gets rid of a warning
when running tests.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/liblcm/72)
<!-- Reviewable:end -->
