### PR TITLE
Adjust for changes in libpalaso

### DIFF
--- a/src/SIL.LCModel.Core/WritingSystems/CoreLdmlInFolderWritingSystemFactory.cs
+++ b/src/SIL.LCModel.Core/WritingSystems/CoreLdmlInFolderWritingSystemFactory.cs
@@ -19,7 +19,7 @@ namespace SIL.LCModel.Core.WritingSystems
 			return new CoreWritingSystemDefinition(ietfLanguageTag);
 		}
 
-		protected override CoreWritingSystemDefinition ConstructDefinition(CoreWritingSystemDefinition ws)
+		protected override CoreWritingSystemDefinition ConstructDefinition(CoreWritingSystemDefinition ws, bool cloneId = false)
 		{
 			return new CoreWritingSystemDefinition(ws);
 		}

--- a/src/SIL.LCModel.Core/WritingSystems/CoreSldrWritingSystemFactory.cs
+++ b/src/SIL.LCModel.Core/WritingSystems/CoreSldrWritingSystemFactory.cs
@@ -14,9 +14,9 @@ namespace SIL.LCModel.Core.WritingSystems
 			return new CoreWritingSystemDefinition(ietfLanguageTag);
 		}
 
-		protected override CoreWritingSystemDefinition ConstructDefinition(CoreWritingSystemDefinition ws)
+		protected override CoreWritingSystemDefinition ConstructDefinition(CoreWritingSystemDefinition ws, bool cloneId = false)
 		{
-			return new CoreWritingSystemDefinition(ws);
+			return new CoreWritingSystemDefinition(ws, cloneId);
 		}
 	}
 }

--- a/src/SIL.LCModel.Core/WritingSystems/CoreWritingSystemDefinition.cs
+++ b/src/SIL.LCModel.Core/WritingSystems/CoreWritingSystemDefinition.cs
@@ -40,8 +40,8 @@ namespace SIL.LCModel.Core.WritingSystems
 		/// <summary>
 		/// Initializes a new instance of the <see cref="CoreWritingSystemDefinition"/> class.
 		/// </summary>
-		public CoreWritingSystemDefinition(CoreWritingSystemDefinition ws)
-			: base(ws)
+		public CoreWritingSystemDefinition(CoreWritingSystemDefinition ws, bool cloneId = false)
+			: base(ws, cloneId)
 		{
 			SetupCollectionChangeListeners();
 		}

--- a/src/SIL.LCModel.Core/WritingSystems/CoreWritingSystemFactory.cs
+++ b/src/SIL.LCModel.Core/WritingSystems/CoreWritingSystemFactory.cs
@@ -14,9 +14,9 @@ namespace SIL.LCModel.Core.WritingSystems
 			return new CoreWritingSystemDefinition(ietfLanguageTag);
 		}
 
-		protected override CoreWritingSystemDefinition ConstructDefinition(CoreWritingSystemDefinition ws)
+		protected override CoreWritingSystemDefinition ConstructDefinition(CoreWritingSystemDefinition ws, bool cloneId = false)
 		{
-			return new CoreWritingSystemDefinition(ws);
+			return new CoreWritingSystemDefinition(ws, cloneId);
 		}
 	}
 }


### PR DESCRIPTION
PR#73 (https://github.com/sillsdev/libpalaso/pull/773) modifies the API to that a writing system doesn't have the timestamp updated when copying to the global store. This change makes the necessary changes on the liblcm side.

This changes requires libpalaso PR#73 before it can be built and merged.