### PR TITLE
Fix creating WS clone

### DIFF
--- a/src/SIL.LCModel.Core/WritingSystems/CoreLdmlInFolderWritingSystemFactory.cs
+++ b/src/SIL.LCModel.Core/WritingSystems/CoreLdmlInFolderWritingSystemFactory.cs
@@ -21,7 +21,7 @@ namespace SIL.LCModel.Core.WritingSystems
 
 		protected override CoreWritingSystemDefinition ConstructDefinition(CoreWritingSystemDefinition ws, bool cloneId = false)
 		{
-			return new CoreWritingSystemDefinition(ws);
+			return new CoreWritingSystemDefinition(ws, cloneId);
 		}
 	}
 }


### PR DESCRIPTION
Commit c89444e1 adjusted liblcm to changes in libpalaso,
but missed one call when creating a duplicate writing system
which resulted in the cloned writing system having a modified
timestamp.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/liblcm/85)
<!-- Reviewable:end -->
