### PR TITLE
Adjust for changes in libpalaso

### DIFF
--- a/src/SIL.LCModel.Core/SIL.LCModel.Core.csproj
+++ b/src/SIL.LCModel.Core/SIL.LCModel.Core.csproj
@@ -86,6 +86,9 @@
       <HintPath>..\..\packages\System.Runtime.InteropServices.RuntimeInformation.4.3.0\lib\net45\System.Runtime.InteropServices.RuntimeInformation.dll</HintPath>
       <Private>True</Private>
     </Reference>
+    <Reference Include="System.ValueTuple, Version=4.0.3.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.ValueTuple.4.5.0\lib\net461\System.ValueTuple.dll</HintPath>
+    </Reference>
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Xml" />
   </ItemGroup>

--- a/src/SIL.LCModel.Core/WritingSystems/CoreLdmlInFolderWritingSystemFactory.cs
+++ b/src/SIL.LCModel.Core/WritingSystems/CoreLdmlInFolderWritingSystemFactory.cs
@@ -19,7 +19,7 @@ namespace SIL.LCModel.Core.WritingSystems
 			return new CoreWritingSystemDefinition(ietfLanguageTag);
 		}
 
-		protected override CoreWritingSystemDefinition ConstructDefinition(CoreWritingSystemDefinition ws)
+		protected override CoreWritingSystemDefinition ConstructDefinition(CoreWritingSystemDefinition ws, bool cloneId = false)
 		{
 			return new CoreWritingSystemDefinition(ws);
 		}

--- a/src/SIL.LCModel.Core/WritingSystems/CoreSldrWritingSystemFactory.cs
+++ b/src/SIL.LCModel.Core/WritingSystems/CoreSldrWritingSystemFactory.cs
@@ -14,9 +14,9 @@ namespace SIL.LCModel.Core.WritingSystems
 			return new CoreWritingSystemDefinition(ietfLanguageTag);
 		}
 
-		protected override CoreWritingSystemDefinition ConstructDefinition(CoreWritingSystemDefinition ws)
+		protected override CoreWritingSystemDefinition ConstructDefinition(CoreWritingSystemDefinition ws, bool cloneId = false)
 		{
-			return new CoreWritingSystemDefinition(ws);
+			return new CoreWritingSystemDefinition(ws, cloneId);
 		}
 	}
 }

--- a/src/SIL.LCModel.Core/WritingSystems/CoreWritingSystemDefinition.cs
+++ b/src/SIL.LCModel.Core/WritingSystems/CoreWritingSystemDefinition.cs
@@ -40,8 +40,8 @@ namespace SIL.LCModel.Core.WritingSystems
 		/// <summary>
 		/// Initializes a new instance of the <see cref="CoreWritingSystemDefinition"/> class.
 		/// </summary>
-		public CoreWritingSystemDefinition(CoreWritingSystemDefinition ws)
-			: base(ws)
+		public CoreWritingSystemDefinition(CoreWritingSystemDefinition ws, bool cloneId = false)
+			: base(ws, cloneId)
 		{
 			SetupCollectionChangeListeners();
 		}

--- a/src/SIL.LCModel.Core/WritingSystems/CoreWritingSystemFactory.cs
+++ b/src/SIL.LCModel.Core/WritingSystems/CoreWritingSystemFactory.cs
@@ -14,9 +14,9 @@ namespace SIL.LCModel.Core.WritingSystems
 			return new CoreWritingSystemDefinition(ietfLanguageTag);
 		}
 
-		protected override CoreWritingSystemDefinition ConstructDefinition(CoreWritingSystemDefinition ws)
+		protected override CoreWritingSystemDefinition ConstructDefinition(CoreWritingSystemDefinition ws, bool cloneId = false)
 		{
-			return new CoreWritingSystemDefinition(ws);
+			return new CoreWritingSystemDefinition(ws, cloneId);
 		}
 	}
 }

--- a/src/SIL.LCModel.Core/packages.config
+++ b/src/SIL.LCModel.Core/packages.config
@@ -5,5 +5,6 @@
   <package id="Newtonsoft.Json" version="11.0.1" targetFramework="net461" />
   <package id="NHunspell" version="1.2.5554.16953" targetFramework="net461" />
   <package id="System.Runtime.InteropServices.RuntimeInformation" version="4.3.0" targetFramework="net461" />
+  <package id="System.ValueTuple" version="4.5.0" targetFramework="net461" />
   <package id="vswhere" version="2.4.1" targetFramework="net461" developmentDependency="true" />
 </packages>

--- a/src/SIL.LCModel/SIL.LCModel.csproj
+++ b/src/SIL.LCModel/SIL.LCModel.csproj
@@ -120,6 +120,9 @@
       <RequiredTargetFramework>3.0</RequiredTargetFramework>
     </Reference>
     <Reference Include="System.ServiceProcess" />
+    <Reference Include="System.ValueTuple, Version=4.0.3.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.ValueTuple.4.5.0\lib\net461\System.ValueTuple.dll</HintPath>
+    </Reference>
     <Reference Include="System.Web" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System" />

--- a/src/SIL.LCModel/packages.config
+++ b/src/SIL.LCModel/packages.config
@@ -3,4 +3,5 @@
   <package id="CommonServiceLocator" version="1.0" targetFramework="net461" />
   <package id="protobuf-net" version="2.0.0.668" targetFramework="net461" />
   <package id="SharpZipLib" version="0.86.0" targetFramework="net461" />
+  <package id="System.ValueTuple" version="4.5.0" targetFramework="net461" />
 </packages>

--- a/tests/SIL.LCModel.Core.Tests/SIL.LCModel.Core.Tests.csproj
+++ b/tests/SIL.LCModel.Core.Tests/SIL.LCModel.Core.Tests.csproj
@@ -93,6 +93,9 @@
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Drawing" />
+    <Reference Include="System.ValueTuple, Version=4.0.3.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.ValueTuple.4.5.0\lib\net461\System.ValueTuple.dll</HintPath>
+    </Reference>
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Xml" />
   </ItemGroup>

--- a/tests/SIL.LCModel.Core.Tests/packages.config
+++ b/tests/SIL.LCModel.Core.Tests/packages.config
@@ -1,4 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="NUnit" version="2.6.4" targetFramework="net461" />
+  <package id="System.ValueTuple" version="4.5.0" targetFramework="net461" />
 </packages>

--- a/tests/SIL.LCModel.Tests/SIL.LCModel.Tests.csproj
+++ b/tests/SIL.LCModel.Tests/SIL.LCModel.Tests.csproj
@@ -130,6 +130,9 @@
     </Reference>
     <Reference Include="System.Core" />
     <Reference Include="System.Drawing" />
+    <Reference Include="System.ValueTuple, Version=4.0.3.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.ValueTuple.4.5.0\lib\net461\System.ValueTuple.dll</HintPath>
+    </Reference>
     <Reference Include="System.Web" />
     <Reference Include="System.Xml">
       <Name>System.XML</Name>

--- a/tests/SIL.LCModel.Tests/packages.config
+++ b/tests/SIL.LCModel.Tests/packages.config
@@ -3,4 +3,5 @@
   <package id="CommonServiceLocator" version="1.0" targetFramework="net461" />
   <package id="NUnit" version="2.6.4" targetFramework="net461" />
   <package id="RhinoMocks" version="3.6.1" targetFramework="net461" />
+  <package id="System.ValueTuple" version="4.5.0" targetFramework="net461" />
 </packages>


### PR DESCRIPTION
PR#73 (https://github.com/sillsdev/libpalaso/pull/773) modifies
the API to that a writing system doesn't have the timestamp
updated when copying to the global store. This change makes the
necessary changes on the liblcm side.

(cherry picked from commit c89444e1b1333a132e58688abe2256ceb71ce706)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/liblcm/86)
<!-- Reviewable:end -->
