### PR TITLE
Fix LT-19219: Crash when looking at text with surrogate pairs

### DIFF
--- a/src/SIL.LCModel.Core/Text/TextExtensions.cs
+++ b/src/SIL.LCModel.Core/Text/TextExtensions.cs
@@ -355,6 +355,8 @@ namespace SIL.LCModel.Core.Text
 			if (ich < 0 || ich >= tss.Length)
 				throw new ArgumentOutOfRangeException("ich");
 
+			if (char.IsLowSurrogate(tss.Text[ich]))
+				--ich;
 			int wsHandle = tss.get_WritingSystemAt(ich);
 			int ch = char.ConvertToUtf32(tss.Text, ich);
 			return TsStringUtils.IsWordForming(ch, wsf, wsHandle);


### PR DESCRIPTION
* Added code to prevent the crash

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/liblcm/89)
<!-- Reviewable:end -->
