### PR TITLE
Revert Changes to Discourse Chart - ON MASTER ONLY

### DIFF
--- a/src/SIL.LCModel/Templates/NewLangProj.fwdata
+++ b/src/SIL.LCModel/Templates/NewLangProj.fwdata
@@ -7170,19 +7170,7 @@
 </Abbreviation>
 <Hidden val="False" />
 <Name>
-<AUni ws="en">Default Template</AUni>
-</Name>
-<SubPossibilities>
-<objsur guid="397636f5-2994-4aee-b6f3-376ca71bddea" t="o" />
-</SubPossibilities>
-</rt>
-<rt class="CmPossibility" guid="397636f5-2994-4aee-b6f3-376ca71bddea" ownerguid="c414012a-ea5e-11de-99fc-0013722f8dec">
-<Abbreviation>
-<AUni ws="en">story</AUni>
-</Abbreviation>
-<Hidden val="False" />
-<Name>
-<AUni ws="en">Story</AUni>
+<AUni ws="en">Default</AUni>
 </Name>
 <SubPossibilities>
 <objsur guid="c41fece2-ea5e-11de-8db3-0013722f8dec" t="o" />


### PR DESCRIPTION
These changes were not well tested but belong in develop

This reverts commit c2d138153f4bdeaadb2b4007b9e8dad44251403a.

# Conflicts:
#	src/SIL.LCModel/Templates/NewLangProj.fwdata

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/liblcm/91)
<!-- Reviewable:end -->
