### PR TITLE
Fix: LT-19437 Space showing in lexical reference fields

### DIFF
--- a/src/SIL.LCModel/DomainImpl/OverridesLing_Lex.cs
+++ b/src/SIL.LCModel/DomainImpl/OverridesLing_Lex.cs
@@ -5559,14 +5559,15 @@ namespace SIL.LCModel.DomainImpl
 			var hc = Services.GetInstance<HomographConfiguration>();
 			if (hc.ShowSenseNumber(hv) && lexEntry.HasMoreThanOneSense)
 			{
-				tisb.Append(" ");
+				var referencedSenseNumber = FormatSenseNumber();
+				if (!string.IsNullOrEmpty(referencedSenseNumber))
+					tisb.Append(" ");
 				tisb.SetStrPropValue((int)FwTextPropType.ktptNamedStyle,
 					HomographConfiguration.ksSenseReferenceNumberStyle);
 				var senseNumberWs = string.IsNullOrEmpty(hc.WritingSystem)
 					 ? Cache.DefaultAnalWs
 					 : Cache.WritingSystemFactory.GetWsFromStr(hc.WritingSystem);
 				tisb.SetIntPropValues((int)FwTextPropType.ktptWs, 0, senseNumberWs);
-				var referencedSenseNumber = FormatSenseNumber();
 				tisb.Append(referencedSenseNumber);
 			}
 		}

--- a/tests/SIL.LCModel.Tests/DomainImpl/SenseOrEntryTests.cs
+++ b/tests/SIL.LCModel.Tests/DomainImpl/SenseOrEntryTests.cs
@@ -32,7 +32,7 @@ namespace SIL.LCModel.DomainImpl
 		}
 
 		[Test]
-		public void ISenseOrEntryHeadwordRef_IncludesReferencedSenseNumber()
+		public void ISenseOrEntryHeadwordRef_SenseNumberNotShownWhenHCSenseIsNotShown()
 		{
 			var mainEntry = CreateInterestingLexEntry(Cache, "MainEntry", "MainSense");
 			AddSenseToEntry(mainEntry, "SecondSense", EnsureWritingSystemSetup(Cache, "en", false), Cache);

--- a/tests/SIL.LCModel.Tests/DomainImpl/SenseOrEntryTests.cs
+++ b/tests/SIL.LCModel.Tests/DomainImpl/SenseOrEntryTests.cs
@@ -1,7 +1,8 @@
-﻿// Copyright (c) 2017 SIL International
+// Copyright (c) 2017 SIL International
 // This software is licensed under the LGPL, version 2.1 or later
 // (http://www.gnu.org/licenses/lgpl-2.1.html)
 
+using System.Linq;
 using NUnit.Framework;
 using SIL.LCModel.Core.Text;
 using SIL.LCModel.Core.WritingSystems;
@@ -22,8 +23,76 @@ namespace SIL.LCModel.DomainImpl
 			var secondSense = new SenseOrEntry(mainEntry.SensesOS[1]);
 			CreateInterestingLexEntry(Cache, "MainEntry", "Nonsense"); // create a homograph
 
+			// Set default sense number style
+			var settings = Cache.ServiceLocator.GetInstance<HomographConfiguration>();
+			settings.ksSenseNumberStyle = "%d";
+
 			// SUT
 			Assert.AreEqual("MainEntry1 2", secondSense.HeadWordRef.BestVernacularAlternative.Text);
+		}
+
+		[Test]
+		public void ISenseOrEntryHeadwordRef_IncludesReferencedSenseNumber()
+		{
+			var mainEntry = CreateInterestingLexEntry(Cache, "MainEntry", "MainSense");
+			AddSenseToEntry(mainEntry, "SecondSense", EnsureWritingSystemSetup(Cache, "en", false), Cache);
+			var secondSense = new SenseOrEntry(mainEntry.SensesOS[1]);
+			var referencedEntry = CreateInterestingLexEntry(Cache);
+
+			CreateLexicalReference(mainEntry, referencedEntry, "");
+			CreateInterestingLexEntry(Cache, "MainEntry", "Nonsense");
+
+			// Set empty sense number style
+			var settings = Cache.ServiceLocator.GetInstance<HomographConfiguration>();
+			settings.ksSenseNumberStyle = "";
+
+			// SUT
+			Assert.AreEqual("MainEntry1", secondSense.HeadWordRef.BestVernacularAlternative.Text);
+		}
+
+		private void CreateLexicalReference(ICmObject mainEntry, ICmObject referencedForm, string refTypeName, string refTypeReverseName = null)
+		{
+			CreateLexicalReference(mainEntry, referencedForm, null, refTypeName, refTypeReverseName);
+		}
+
+		private void CreateLexicalReference(ICmObject firstEntry, ICmObject secondEntry, ICmObject thirdEntry, string refTypeName, string refTypeReverseName = null)
+		{
+			var lrt = CreateLexRefType(LexRefTypeTags.MappingTypes.kmtEntryOrSenseSequence, refTypeName, "", refTypeReverseName, "");
+			if (!string.IsNullOrEmpty(refTypeReverseName))
+			{
+				lrt.ReverseName.set_String(Cache.DefaultAnalWs, refTypeReverseName);
+				lrt.MappingType = (int)MappingTypes.kmtEntryOrSenseTree;
+			}
+			var lexRef = Cache.ServiceLocator.GetInstance<ILexReferenceFactory>().Create();
+			lrt.MembersOC.Add(lexRef);
+			lexRef.TargetsRS.Add(firstEntry);
+			lexRef.TargetsRS.Add(secondEntry);
+			if (thirdEntry != null)
+				lexRef.TargetsRS.Add(thirdEntry);
+		}
+
+		private ILexRefType CreateLexRefType(LexRefTypeTags.MappingTypes type, string name, string abbr, string revName, string revAbbr)
+		{
+			int wsEn = Cache.WritingSystemFactory.GetWsFromStr("en");
+			if (Cache.LangProject.LexDbOA.ReferencesOA == null)
+			{
+				Cache.LangProject.LexDbOA.ReferencesOA = Cache.ServiceLocator.GetInstance<ICmPossibilityListFactory>().Create();
+			}
+			var referencePossibilities = Cache.LangProject.LexDbOA.ReferencesOA.PossibilitiesOS;
+			if (referencePossibilities.Any(r => r.Name.BestAnalysisAlternative.Text == name))
+			{
+				return referencePossibilities.First(r => r.Name.BestAnalysisAlternative.Text == name) as ILexRefType;
+			}
+			var lrt = Cache.ServiceLocator.GetInstance<ILexRefTypeFactory>().Create();
+			referencePossibilities.Add(lrt);
+			lrt.MappingType = (int)type;
+			lrt.Name.set_String(wsEn, name);
+			lrt.Abbreviation.set_String(wsEn, abbr);
+			if (!string.IsNullOrEmpty(revName))
+				lrt.ReverseName.set_String(wsEn, revName);
+			if (!string.IsNullOrEmpty(revAbbr))
+				lrt.ReverseAbbreviation.set_String(wsEn, revAbbr);
+			return lrt;
 		}
 
 		/// <summary>


### PR DESCRIPTION
* Changed the code to remove space
* Added unit test to test the change

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/liblcm/93)
<!-- Reviewable:end -->
