### PR TITLE
[API] Filter non-ASCII characters out of project names

### DIFF
--- a/src/SIL.LCModel.Utils/MiscUtils.cs
+++ b/src/SIL.LCModel.Utils/MiscUtils.cs
@@ -317,7 +317,7 @@ namespace SIL.LCModel.Utils
 		/// ------------------------------------------------------------------------------------
 		public static string FilterForFileName(string sName, FilenameFilterStrength strength)
 		{
-			return StringUtils.FilterForFileName(sName, GetInvalidProjectNameChars(strength));
+			return StringUtils.FilterForFileName(sName, GetInvalidProjectNameChars(strength), strength);
 		}
 
 		/// ------------------------------------------------------------------------------------

--- a/src/SIL.LCModel.Utils/StringUtils.cs
+++ b/src/SIL.LCModel.Utils/StringUtils.cs
@@ -196,9 +196,11 @@ namespace SIL.LCModel.Utils
 		/// </summary>
 		/// <param name="sName">Name to be filtered</param>
 		/// <param name="invalidChars">characters to filter out</param>
+		/// <param name="strength">strength of the filter (<c>kFilterProjName</c> will also remove all non-ASCII characters)</param>
 		/// <returns>the filtered name</returns>
 		/// ------------------------------------------------------------------------------------
-		public static string FilterForFileName(string sName, string invalidChars)
+		public static string FilterForFileName(string sName, string invalidChars,
+			MiscUtils.FilenameFilterStrength strength = MiscUtils.FilenameFilterStrength.kFilterBackup)
 		{
 			StringBuilder cleanName = new StringBuilder(sName);
 
@@ -206,6 +208,8 @@ namespace SIL.LCModel.Utils
 			for (int i = 0; i < sName.Length; i++)
 			{
 				if (invalidChars.IndexOf(sName[i]) >= 0 || sName[i] < ' ') // eliminate all control characters too
+					cleanName[i] = '_';
+				else if (strength == MiscUtils.FilenameFilterStrength.kFilterProjName && sName[i] > '~')
 					cleanName[i] = '_';
 			}
 			return cleanName.ToString();

--- a/src/SIL.LCModel/LcmCache.cs
+++ b/src/SIL.LCModel/LcmCache.cs
@@ -683,7 +683,7 @@ namespace SIL.LCModel
 		/// ------------------------------------------------------------------------------------
 		private static string CreateNewDbFile(string projectsDir, string templateDir, ref string projectName)
 		{
-			projectName = MiscUtils.FilterForFileName(projectName, MiscUtils.FilenameFilterStrength.kFilterBackup);
+			projectName = MiscUtils.FilterForFileName(projectName, MiscUtils.FilenameFilterStrength.kFilterProjName);
 			if (ProjectInfo.GetProjectInfoByName(projectsDir, projectName) != null)
 				throw new ArgumentException("The specified project already exists.", "projectName");
 			string dbDirName = Path.Combine(projectsDir, projectName);

--- a/tests/SIL.LCModel.Utils.Tests/MiscUtilsTest.cs
+++ b/tests/SIL.LCModel.Utils.Tests/MiscUtilsTest.cs
@@ -141,8 +141,8 @@ namespace SIL.LCModel.Utils
 		[Test]
 		public void FilterForFileName_Windows_Invalid()
 		{
-			Assert.AreEqual("My__File__Dude_____.'[];funny()___",
-				MiscUtils.FilterForFileName(@"My?|File<>Dude\?*:/.'[];funny()" + "\n\t" + '"',
+			Assert.AreEqual("My__File__Dude_____.'[];funñy()___\u0344\u0361\u0513\u0307",
+				MiscUtils.FilterForFileName(@"My?|File<>Dude\?*:/.'[];funñy()" + "\n\t" + '"' + "\u0344\u0361\u0513\u0307",
 				MiscUtils.FilenameFilterStrength.kFilterBackup));
 		}
 
@@ -155,8 +155,8 @@ namespace SIL.LCModel.Utils
 		[Test]
 		public void FilterForFileName_MSDE_Invalid()
 		{
-			Assert.AreEqual("My__File__Dude_____.'___funny()___",
-				MiscUtils.FilterForFileName(@"My?|File<>Dude\?*:/.'[];funny()" + "\n\t" + '"',
+			Assert.AreEqual("My__File__Dude_____.'___funñy()___\u0344\u0361\u0513\u0307",
+				MiscUtils.FilterForFileName(@"My?|File<>Dude\?*:/.'[];funñy()" + "\n\t" + '"' + "\u0344\u0361\u0513\u0307",
 				MiscUtils.FilenameFilterStrength.kFilterMSDE));
 		}
 
@@ -169,8 +169,8 @@ namespace SIL.LCModel.Utils
 		[Test]
 		public void FilterForFileName_ProjName_Invalid()
 		{
-			Assert.AreEqual("My__File__Dude_____.'___funny_____",
-				MiscUtils.FilterForFileName(@"My?|File<>Dude\?*:/.'[];funny()" + "\n\t" + '"',
+			Assert.AreEqual("My__File__Dude_____.'___fun_y_________",
+				MiscUtils.FilterForFileName(@"My?|File<>Dude\?*:/.'[];funñy()" + "\n\t" + '"' + "\u0344\u0361\u0513\u0307",
 				MiscUtils.FilenameFilterStrength.kFilterProjName));
 		}
 


### PR DESCRIPTION
* Add an optional parameter to StringUtils.FilterForFileName to remove
  non-ASCII characters
* In spite of our best efforts, these characters still cause occasional
  S/R problems in mercurial, so we will avoid using them
* Addresses https://jira.sil.org/browse/LT-19693

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/liblcm/98)
<!-- Reviewable:end -->
