### PR TITLE
LT-19632: Share WS Data w/ SLDR by default

### DIFF
--- a/src/SIL.LCModel/LcmCache.cs
+++ b/src/SIL.LCModel/LcmCache.cs
@@ -417,6 +417,8 @@ namespace SIL.LCModel
 					progressDlg.Step(0);
 				}
 
+				SetDefaultProjectSettings(cache.ServiceLocator.DataSetup.ProjectSettingsStore);
+
 				cache.ActionHandlerAccessor.BeginNonUndoableTask();
 
 				CreateAnalysisWritingSystem(cache, analWrtSys, true);
@@ -524,6 +526,12 @@ namespace SIL.LCModel
 				}
 			}
 			return dbFileName;
+		}
+
+		/// <summary>Share Writing System data with SLDR by default (LT-19632)</summary>
+		private static void SetDefaultProjectSettings(ISettingsStore projectSettingsStore)
+		{
+			new ProjectLexiconSettingsDataMapper(projectSettingsStore).Write(new ProjectLexiconSettings { AddWritingSystemsToSldr = true });
 		}
 
 		/// <summary>
@@ -657,25 +665,25 @@ namespace SIL.LCModel
 				mapLocalWs.Add(wsT.Id, wsT);
 			using (var rdr = new StreamReader(fileName, Encoding.UTF8))
 			{
-			string sLine;
-			while ((sLine = rdr.ReadLine()) != null)
-			{
-				var idx = sLine.IndexOf(" ws=\"");
-				if (idx < 0)
-					continue;
-				idx += 5;
-				var idxLim = sLine.IndexOf("\"", idx);
-				if (idxLim < 0)
-					continue;
-				var sWs = sLine.Substring(idx, idxLim - idx);
-				if (mapLocalWs.ContainsKey(sWs))
-					continue;
-				CoreWritingSystemDefinition wsNew;
-				wsm.GetOrSet(sWs, out wsNew);
-				mapLocalWs.Add(sWs, wsNew);
+				string sLine;
+				while ((sLine = rdr.ReadLine()) != null)
+				{
+					var idx = sLine.IndexOf(" ws=\"");
+					if (idx < 0)
+						continue;
+					idx += 5;
+					var idxLim = sLine.IndexOf("\"", idx);
+					if (idxLim < 0)
+						continue;
+					var sWs = sLine.Substring(idx, idxLim - idx);
+					if (mapLocalWs.ContainsKey(sWs))
+						continue;
+					CoreWritingSystemDefinition wsNew;
+					wsm.GetOrSet(sWs, out wsNew);
+					mapLocalWs.Add(sWs, wsNew);
+				}
+				rdr.Close();
 			}
-			rdr.Close();
-		}
 		}
 
 		/// ------------------------------------------------------------------------------------

--- a/tests/SIL.LCModel.Tests/LcmCacheTests.cs
+++ b/tests/SIL.LCModel.Tests/LcmCacheTests.cs
@@ -93,7 +93,7 @@ namespace SIL.LCModel
 			try
 			{
 				string dbFileName = LcmCache.CreateNewLangProj(new DummyProgressDlg(), dbName, m_lcmDirectories,
-					new SingleThreadedSynchronizeInvoke(), null, null, null, null, null, null, true);
+					new SingleThreadedSynchronizeInvoke());
 
 				currentDirs = new List<string>(Directory.GetDirectories(m_projectsDirectory));
 				if (currentDirs.Contains(writingSystemsCommonDir) && !expectedDirs.Contains(writingSystemsCommonDir))
@@ -122,7 +122,7 @@ namespace SIL.LCModel
 			{
 				// create project
 				string dbFileName = LcmCache.CreateNewLangProj(new DummyProgressDlg(), dbName, m_lcmDirectories,
-					new SingleThreadedSynchronizeInvoke(), null, null, null, null, null, null, true);
+					new SingleThreadedSynchronizeInvoke());
 
 				var projectId = new TestProjectId(BackendProviderType.kXMLWithMemoryOnlyWsMgr, dbFileName);
 				using (var cache = LcmCache.CreateCacheFromExistingData(projectId, "en", m_ui, m_lcmDirectories, new LcmSettings(),
@@ -311,7 +311,7 @@ namespace SIL.LCModel
 			{
 				// create project
 				string dbFileName = LcmCache.CreateNewLangProj(new DummyProgressDlg(), dbName, m_lcmDirectories,
-					new SingleThreadedSynchronizeInvoke(), null, null, null, null, null, null, true);
+					new SingleThreadedSynchronizeInvoke());
 				// Set up test file for project sharing setting
 				var testFileStore = new FileSettingsStore(LexiconSettingsFileHelper.GetProjectLexiconSettingsPath(Path.GetDirectoryName(dbFileName)));
 				var dataMapper = new ProjectLexiconSettingsDataMapper(testFileStore);


### PR DESCRIPTION
If the user has not set the FEEDBACK=off environment variable,
then enable sharing of Writing System data with SLDR for new projects.
https://jira.sil.org/browse/LT-19632

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/liblcm/103)
<!-- Reviewable:end -->
