### PR TITLE
Allow to store `null` value in SingletonsContainer

### DIFF
--- a/src/SIL.LCModel.Utils/SingletonsContainer.cs
+++ b/src/SIL.LCModel.Utils/SingletonsContainer.cs
@@ -52,7 +52,7 @@ namespace SIL.LCModel.Utils
 				try
 				{
 					foreach (var keyValuePair in m_SingletonsToDispose)
-						keyValuePair.Value.Dispose();
+						keyValuePair.Value?.Dispose();
 
 					m_SingletonsToDispose.Clear();
 				}
@@ -215,8 +215,7 @@ namespace SIL.LCModel.Utils
 		/// ------------------------------------------------------------------------------------
 		public static void Release()
 		{
-			if (s_container != null)
-				s_container.DisposeSingletons();
+			s_container?.DisposeSingletons();
 			s_container = null;
 		}
 
@@ -411,7 +410,7 @@ namespace SIL.LCModel.Utils
 		/// <summary>Determines if a singleton of the specified type was created before.</summary>
 		/// <typeparam name="T">The type of the singleton. Needs to implement
 		/// IDisposable.</typeparam>
-		/// <remarks>This method checks the existance of a previously constructed singleton of the
+		/// <remarks>This method checks the existence of a previously constructed singleton of the
 		/// specified type.</remarks>
 		/// ------------------------------------------------------------------------------------
 		public static bool Contains<T>() where T: IDisposable
@@ -424,7 +423,7 @@ namespace SIL.LCModel.Utils
 		/// <param name="key">The key of the singleton.</param>
 		/// <typeparam name="T">The type of the singleton. Needs to implement
 		/// IDisposable.</typeparam>
-		/// <remarks>This method checks the existance of a previously constructed singleton of the
+		/// <remarks>This method checks the existence of a previously constructed singleton of the
 		/// specified type and key.</remarks>
 		/// ------------------------------------------------------------------------------------
 		public static bool Contains<T>(string key) where T: IDisposable

--- a/tests/SIL.LCModel.Utils.Tests/SingletonsContainerTests.cs
+++ b/tests/SIL.LCModel.Utils.Tests/SingletonsContainerTests.cs
@@ -85,7 +85,7 @@ namespace SIL.LCModel.Utils
 		/// </summary>
 		///--------------------------------------------------------------------------------------
 		[Test]
-		public void SingletonProperlyDisposed()
+		public void DisposeSingletons_ProperlyDisposed()
 		{
 			using (var singleton = new MyDisposable())
 			{
@@ -99,6 +99,16 @@ namespace SIL.LCModel.Utils
 			}
 		}
 
+		[Test]
+		public void DisposeSingletons_NullSingleton_DoesNotCrash()
+		{
+			SingletonsContainer.Add(typeof(MyDisposable).FullName, null);
+
+			Assert.That(() => SingletonsContainer.Release(), Throws.Nothing);
+
+			Assert.That(SingletonsContainer.Contains<MyDisposable>(), Is.False);
+		}
+
 		///--------------------------------------------------------------------------------------
 		/// <summary>
 		/// Tests that singletons get properly disposed. This tests the Add method that
@@ -106,7 +116,7 @@ namespace SIL.LCModel.Utils
 		/// </summary>
 		///--------------------------------------------------------------------------------------
 		[Test]
-		public void SingletonProperlyDisposedAutoKey()
+		public void DisposeSingletons_ProperlyDisposedAutoKey()
 		{
 			using (var singleton = new MyDisposable())
 			{


### PR DESCRIPTION
This allows to disable the global writing system store. This is beneficial for LfMerge where we deal with projects from different people that shouldn't share a global store.

To disable the global writing system store you'd call

```csharp
SingletonsContainer.Add(typeof(CoreGlobalWritingSystemRepository).FullName, null);
```

from client code before you create the `LcmCache`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/liblcm/104)
<!-- Reviewable:end -->
