### PR TITLE
Fix SingletonsContainer.Contains for `null` value

### DIFF
--- a/src/SIL.LCModel.Utils/SingletonsContainer.cs
+++ b/src/SIL.LCModel.Utils/SingletonsContainer.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2011-2017 SIL International
+// Copyright (c) 2011-2019 SIL International
 // This software is licensed under the LGPL, version 2.1 or later
 // (http://www.gnu.org/licenses/lgpl-2.1.html)
 
@@ -175,7 +175,7 @@ namespace SIL.LCModel.Utils
 			/// <typeparam name="T">The type of the singleton. Needs to implement
 			/// IDisposable.</typeparam>
 			/// <param name="key">The key of the singleton.</param>
-			/// <remarks>This method checks the existance of a previously constructed singleton
+			/// <remarks>This method checks the existence of a previously constructed singleton
 			/// of the specified type and key.</remarks>
 			/// --------------------------------------------------------------------------------
 			public bool Contains<T>(string key) where T : IDisposable
@@ -183,9 +183,8 @@ namespace SIL.LCModel.Utils
 				m_lock.EnterReadLock();
 				try
 				{
-					IDisposable singleton;
-					if (m_SingletonsToDispose.TryGetValue(key, out singleton))
-						return singleton is T;
+					if (m_SingletonsToDispose.TryGetValue(key, out var singleton))
+						return singleton is T || Equals(singleton, default(T));
 					return false;
 				}
 				finally

--- a/tests/SIL.LCModel.Utils.Tests/SingletonsContainerTests.cs
+++ b/tests/SIL.LCModel.Utils.Tests/SingletonsContainerTests.cs
@@ -333,7 +333,7 @@ namespace SIL.LCModel.Utils
 		}
 
 		/// <summary>
-		/// Tests checking the existance of a singleton. In this case the singleton wasn't
+		/// Tests checking the existence of a singleton. In this case the singleton wasn't
 		/// created before.
 		/// </summary>
 		[Test]
@@ -343,7 +343,7 @@ namespace SIL.LCModel.Utils
 		}
 
 		/// <summary>
-		/// Tests checking the existance of a singleton. In this case the singleton was
+		/// Tests checking the existence of a singleton. In this case the singleton was
 		/// created before.
 		/// </summary>
 		[Test]
@@ -356,7 +356,7 @@ namespace SIL.LCModel.Utils
 		}
 
 		/// <summary>
-		/// Tests checking the existance of a singleton with the specified key. In this case the
+		/// Tests checking the existence of a singleton with the specified key. In this case the
 		/// singleton wasn't created before.
 		/// </summary>
 		[Test]
@@ -366,7 +366,7 @@ namespace SIL.LCModel.Utils
 		}
 
 		/// <summary>
-		/// Tests checking the existance of a singleton with the specified key. In this case the
+		/// Tests checking the existence of a singleton with the specified key. In this case the
 		/// singleton was created before.
 		/// </summary>
 		[Test]
@@ -379,7 +379,7 @@ namespace SIL.LCModel.Utils
 		}
 
 		/// <summary>
-		/// Tests checking the existance of a singleton with the specified key. In this case a
+		/// Tests checking the existence of a singleton with the specified key. In this case a
 		/// singleton with a different key was created before.
 		/// </summary>
 		[Test]
@@ -392,7 +392,7 @@ namespace SIL.LCModel.Utils
 		}
 
 		/// <summary>
-		/// Tests checking the existance of a singleton with the specified key. In this case a
+		/// Tests checking the existence of a singleton with the specified key. In this case a
 		/// singleton with a different type was created before.
 		/// </summary>
 		[Test]
@@ -402,6 +402,16 @@ namespace SIL.LCModel.Utils
 			{
 				Assert.IsFalse(SingletonsContainer.Contains<DummyDisposable>("foo"));
 			}
+		}
+
+		/// <summary>
+		/// Tests checking the existence of a key with the value null.
+		/// </summary>
+		[Test]
+		public void ContainsNullSingleton()
+		{
+			SingletonsContainer.Add(typeof(MyDisposable).FullName, null);
+			Assert.That(SingletonsContainer.Contains<MyDisposable>(), Is.True);
 		}
 	}
 }


### PR DESCRIPTION
The previous commit allowed to store `null` value in
SingletonsContainer. This change fixes the Contains method so that
we properly return `true` if a `null` value is stored for a type.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/liblcm/106)
<!-- Reviewable:end -->
