### PR TITLE
Tag SpellEngineWindows to not be included in Linux ILRepack run

### DIFF
--- a/src/SIL.LCModel.Core/SpellChecking/SpellEngineWindows.cs
+++ b/src/SIL.LCModel.Core/SpellChecking/SpellEngineWindows.cs
@@ -10,6 +10,15 @@ using NHunspell;
 
 namespace SIL.LCModel.Core.SpellChecking
 {
+	/// <summary>ILRepacking SpellEngineWindows into a dll, and then loading that dll in Linux (such as in mono5-sil)
+	/// crashes, saying Msg: Could not load type of field
+	/// 'SIL.LCModel.Core.SpellChecking.SpellEngineWindows:_hunspellHandle' (0) due to: Could not load file or assembly
+	/// NHunspell. Instructing ILRepack to omit SpellEngineWindows (by attribute) prevents that crash. </summary>
+	internal class NoLinuxRepack : System.Attribute
+	{
+	}
+
+	[NoLinuxRepack]
 	internal sealed class SpellEngineWindows: SpellEngine
 	{
 		private readonly Hunspell _hunspellHandle;


### PR DESCRIPTION
* Part of fixing crash in FW LT-20126.
* I would think it would now complain that SpellEngine.cs is using an
unresolvable type, SpellEngineWindows, but it must be implemented in a
way that that's not a problem.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/liblcm/127)
<!-- Reviewable:end -->
