### PR TITLE
Fix crash from casting TsTextProps (LT-20002)

### DIFF
--- a/src/SIL.LCModel.Core/Text/TsPropsFactory.cs
+++ b/src/SIL.LCModel.Core/Text/TsPropsFactory.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2016 SIL International
+// Copyright (c) 2016 SIL International
 // This software is licensed under the LGPL, version 2.1 or later
 // (http://www.gnu.org/licenses/lgpl-2.1.html)
 
@@ -67,6 +67,27 @@ namespace SIL.LCModel.Core.Text
 			// TODO: should we support magic writing system codes?
 			if (ws < 0)
 				throw new ArgumentOutOfRangeException(paramName);
+		}
+
+		public TsTextProps FromITsTextProps(ITsTextProps ttp)
+		{
+			var bldr = new TsPropsBldr();
+			int countIntProps = ttp.IntPropCount;
+			for (int i = 0; i < countIntProps; i++)
+			{
+				int tpt, ttv;
+				var val = ttp.GetIntProp(i, out tpt, out ttv);
+				bldr.SetIntPropValues(tpt, ttv, val);
+			}
+
+			int countStrProps = ttp.StrPropCount;
+			for (int i = 0; i < countStrProps; i++)
+			{
+				int tpt;
+				var val = ttp.GetStrProp(i, out tpt);
+				bldr.SetStrPropValue(tpt, val);
+			}
+			return (TsTextProps) bldr.GetTextProps();
 		}
 	}
 }

--- a/src/SIL.LCModel.Core/Text/TsStrBldr.cs
+++ b/src/SIL.LCModel.Core/Text/TsStrBldr.cs
@@ -106,7 +106,12 @@ namespace SIL.LCModel.Core.Text
 			}
 			else
 			{
-				textProps = (TsTextProps) ttp;
+				textProps = ttp as TsTextProps;
+				if (textProps == null && ttp != null)
+				{
+					// if it came from C++, could be wrapped in a way that prevents a simple cast.
+					textProps = ((TsPropsFactory)TsStringUtils.TsPropsFactory).FromITsTextProps(ttp);
+				}
 			}
 
 			TsRun run = new TsRun(cchIns, textProps);
@@ -218,7 +223,12 @@ namespace SIL.LCModel.Core.Text
 			ThrowIfCharOffsetOutOfRange("ichLim", ichLim, Length);
 			ThrowIfParamNull("ttp", ttp);
 
-			var textProps = (TsTextProps) ttp;
+			var textProps = ttp as TsTextProps;
+			if (textProps == null)
+			{
+				// if it came from C++, could be wrapped in a way that prevents a simple cast.
+				textProps = ((TsPropsFactory) TsStringUtils.TsPropsFactory).FromITsTextProps(ttp);
+			}
 
 			if (ichMin == ichLim)
 			{

--- a/src/SIL.LCModel.Core/Text/TsStrFactory.cs
+++ b/src/SIL.LCModel.Core/Text/TsStrFactory.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2016 SIL International
+// Copyright (c) 2016 SIL International
 // This software is licensed under the LGPL, version 2.1 or later
 // (http://www.gnu.org/licenses/lgpl-2.1.html)
 
@@ -45,7 +45,14 @@ namespace SIL.LCModel.Core.Text
 			if (ttp == null)
 				throw new ArgumentNullException("ttp");
 
-			return new TsString(rgch == null ? null : rgch.Substring(0, cch), (TsTextProps) ttp);
+			var textProps = ttp as TsTextProps;
+			if (textProps == null)
+			{
+				// if it came from C++, could be wrapped in a way that prevents a simple cast.
+				textProps = ((TsPropsFactory)TsStringUtils.TsPropsFactory).FromITsTextProps(ttp);
+			}
+
+			return new TsString(rgch == null ? null : rgch.Substring(0, cch), textProps);
 		}
 
 		/// <summary>

--- a/tests/SIL.LCModel.Core.Tests/Text/TsPropsFactoryTests.cs
+++ b/tests/SIL.LCModel.Core.Tests/Text/TsPropsFactoryTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2016 SIL International
+// Copyright (c) 2016 SIL International
 // This software is licensed under the LGPL, version 2.1 or later
 // (http://www.gnu.org/licenses/lgpl-2.1.html)
 
@@ -41,6 +41,17 @@ namespace SIL.LCModel.Core.Text
 		{
 			var tpf = new TsPropsFactory();
 			Assert.That(() => tpf.MakeProps("Style", -1, -1), Throws.InstanceOf<ArgumentOutOfRangeException>());
+		}
+
+		[Test]
+		public void FromITsTextProps_IntAndStringProps_Copies()
+		{
+			var tpf = new TsPropsFactory();
+			var original = tpf.MakeProps("someStyle", 43, 57) as ITsTextProps;
+
+			var copy = tpf.FromITsTextProps(original);
+			string diff;
+			Assert.That(TsTextPropsHelper.PropsAreEqual(original, copy, out diff));
 		}
 	}
 }


### PR DESCRIPTION
Seems when a C# object has been marshaled for COM  and passed to C++ and back, a simple cast will not work to get back to the implementing C# object. I can't find what will, so took another approach.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/liblcm/128)
<!-- Reviewable:end -->
