### PR TITLE
Fix "Missing" VSWhere

### DIFF
--- a/LCM.sln.DotSettings
+++ b/LCM.sln.DotSettings
@@ -1,0 +1,5 @@
+﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=flid/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=ownerless/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=Subentry/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=subrecords/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>

--- a/src/SIL.LCModel.Core/BuildInclude.targets
+++ b/src/SIL.LCModel.Core/BuildInclude.targets
@@ -17,13 +17,14 @@
 		<KernelOutputs Include="$(OutDir)KernelInterfaces/FwKernelTlb.iip" />
 		<KernelOutputs Include="$(OutDir)KernelInterfaces/FwKernelTlb.json" />
 	</ItemGroup>
-	<Target Name="SetInstallLocation">
-		<Exec Command="$(VSWhereDir)\vswhere -latest -products * -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 -property installationPath" ConsoleToMSBuild="true" Condition="'$(OS)'=='Windows_NT'">
+	<Target Name="SetVSInstallLocation">
+		<Error Condition="!Exists('$(VSWhereDir)')" Text="VSWhereDir not found. If you are building from a clean repository, restart Visual Studio and try again (looking in '$(VSWhereDir)')."/>
+		<Exec Command="$(VSWhereDir)vswhere -latest -products * -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 -property installationPath" ConsoleToMSBuild="true" Condition="'$(OS)'=='Windows_NT'">
 			<Output TaskParameter="ConsoleOutput" PropertyName="VSInstallDir" />
 		</Exec>
 	</Target>
 
-	<Target Name="GenerateKernelCs" Inputs="@(KernelInputs)" Outputs="@(KernelOutputs)" DependsOnTargets="SetInstallLocation">
+	<Target Name="GenerateKernelCs" Inputs="@(KernelInputs)" Outputs="@(KernelOutputs)" DependsOnTargets="SetVSInstallLocation">
 		<!-- Call the IdlImp task from SIL.LCModel.Build.Tasks in a separate msbuild process,
 		     so it doesn't lock the SIL.LCModel.Build.Tasks.dll in VS. -->
 		<Exec Command="$(MsbuildCommand) GenerateKernelCs.proj /p:OutDir=$(OutDir) /p:IntermediateOutputPath=$(IntermediateOutputPath) /p:Platform=$(Platform) /p:VSInstallDir=&quot;$(VSInstallDir)&quot;" />

--- a/src/SIL.LCModel.Core/BuildInclude.targets
+++ b/src/SIL.LCModel.Core/BuildInclude.targets
@@ -19,14 +19,13 @@
 	</ItemGroup>
 	<Target Name="SetVSInstallDir" Condition="'$(OS)'=='Windows_NT'">
 		<ItemGroup>
-			<PackageReference Include="vswhere" Version="2.4.1" GeneratePathProperty="true" Condition="'$(OS)'=='Windows_NT'">
+			<PackageReference Include="vswhere" Version="2.4.1">
 				<PrivateAssets>all</PrivateAssets>
 				<IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
 			</PackageReference>
 		</ItemGroup>
 		<PropertyGroup>
-			<VSWhereDir Condition="'$(Pkgvswhere)'!=''">>$(Pkgvswhere)\tools</VSWhereDir>
-			<!--<VSWhereDir Condition="'$(Pkgvswhere)'==''">>$(NuGetPackageRoot)TODO\tools</VSWhereDir>-->
+			<VSWhereDir>$(NuGetPackageRoot)vswhere\2.4.1\tools</VSWhereDir>
 		</PropertyGroup>
 		<Exec Command="$(VSWhereDir)\vswhere -latest -products * -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 -property installationPath" ConsoleToMSBuild="true" Condition="'$(OS)'=='Windows_NT'">
 			<Output TaskParameter="ConsoleOutput" PropertyName="VSInstallDir" />

--- a/src/SIL.LCModel.Core/BuildInclude.targets
+++ b/src/SIL.LCModel.Core/BuildInclude.targets
@@ -5,6 +5,7 @@
 		<IntermediateOutputPath Condition="'$(IntermediateOutputPath)' == ''">obj/x86/$(Configuration)/</IntermediateOutputPath>
 		<MsbuildCommand Condition="'$(OS)'=='Windows_NT' And '$(MsBuildCommand)'==''">"$(MSBuildBinPath)\msbuild.exe"</MsbuildCommand>
 		<MsbuildCommand Condition="'$(OS)'=='Unix' And '$(MsBuildCommand)'==''">xbuild</MsbuildCommand>
+		<VSWhereDir>..\..\packages\vswhere.2.4.1\tools\</VSWhereDir>
 	</PropertyGroup>
 
 	<ItemGroup>
@@ -18,7 +19,7 @@
 		<KernelOutputs Include="$(OutDir)KernelInterfaces/FwKernelTlb.json" />
 	</ItemGroup>
 	<Target Name="SetVSInstallLocation">
-		<Error Condition="!Exists('$(VSWhereDir)')" Text="VSWhereDir not found. If you are building from a clean repository, restart Visual Studio and try again (looking in '$(VSWhereDir)')."/>
+		<Error Condition="'$(OS)'=='Windows_NT' And !Exists('$(VSWhereDir)')" Text="VSWhereDir not found (looking in '$(VSWhereDir)')."/>
 		<Exec Command="$(VSWhereDir)vswhere -latest -products * -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 -property installationPath" ConsoleToMSBuild="true" Condition="'$(OS)'=='Windows_NT'">
 			<Output TaskParameter="ConsoleOutput" PropertyName="VSInstallDir" />
 		</Exec>

--- a/src/SIL.LCModel.Core/BuildInclude.targets
+++ b/src/SIL.LCModel.Core/BuildInclude.targets
@@ -5,6 +5,7 @@
 		<IntermediateOutputPath Condition="'$(IntermediateOutputPath)' == ''">obj/x86/$(Configuration)/</IntermediateOutputPath>
 		<MsbuildCommand Condition="'$(OS)'=='Windows_NT' And '$(MsBuildCommand)'==''">"$(MSBuildBinPath)\msbuild.exe"</MsbuildCommand>
 		<MsbuildCommand Condition="'$(OS)'=='Unix' And '$(MsBuildCommand)'==''">xbuild</MsbuildCommand>
+		<VSWhereCommand>..\..\packages\vswhere.2.4.1\tools\vswhere</VSWhereCommand>
 	</PropertyGroup>
 
 	<ItemGroup>
@@ -18,16 +19,7 @@
 		<KernelOutputs Include="$(OutDir)KernelInterfaces/FwKernelTlb.json" />
 	</ItemGroup>
 	<Target Name="SetVSInstallDir" Condition="'$(OS)'=='Windows_NT'">
-		<ItemGroup>
-			<PackageReference Include="vswhere" Version="2.4.1">
-				<PrivateAssets>all</PrivateAssets>
-				<IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
-			</PackageReference>
-		</ItemGroup>
-		<PropertyGroup>
-			<VSWhereDir>$(NuGetPackageRoot)vswhere\2.4.1\tools</VSWhereDir>
-		</PropertyGroup>
-		<Exec Command="$(VSWhereDir)\vswhere -latest -products * -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 -property installationPath" ConsoleToMSBuild="true" Condition="'$(OS)'=='Windows_NT'">
+		<Exec Command="$(VSWhereCommand) -latest -products * -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 -property installationPath" ConsoleToMSBuild="true" Condition="'$(OS)'=='Windows_NT'">
 			<Output TaskParameter="ConsoleOutput" PropertyName="VSInstallDir" />
 		</Exec>
 	</Target>

--- a/src/SIL.LCModel.Core/BuildInclude.targets
+++ b/src/SIL.LCModel.Core/BuildInclude.targets
@@ -5,7 +5,6 @@
 		<IntermediateOutputPath Condition="'$(IntermediateOutputPath)' == ''">obj/x86/$(Configuration)/</IntermediateOutputPath>
 		<MsbuildCommand Condition="'$(OS)'=='Windows_NT' And '$(MsBuildCommand)'==''">"$(MSBuildBinPath)\msbuild.exe"</MsbuildCommand>
 		<MsbuildCommand Condition="'$(OS)'=='Unix' And '$(MsBuildCommand)'==''">xbuild</MsbuildCommand>
-		<VSWhereDir>..\..\packages\vswhere.2.4.1\tools\</VSWhereDir>
 	</PropertyGroup>
 
 	<ItemGroup>
@@ -18,14 +17,23 @@
 		<KernelOutputs Include="$(OutDir)KernelInterfaces/FwKernelTlb.iip" />
 		<KernelOutputs Include="$(OutDir)KernelInterfaces/FwKernelTlb.json" />
 	</ItemGroup>
-	<Target Name="SetVSInstallLocation">
-		<Error Condition="'$(OS)'=='Windows_NT' And !Exists('$(VSWhereDir)')" Text="VSWhereDir not found (looking in '$(VSWhereDir)')."/>
-		<Exec Command="$(VSWhereDir)vswhere -latest -products * -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 -property installationPath" ConsoleToMSBuild="true" Condition="'$(OS)'=='Windows_NT'">
+	<Target Name="SetVSInstallDir" Condition="'$(OS)'=='Windows_NT'">
+		<ItemGroup>
+			<PackageReference Include="vswhere" Version="2.4.1" GeneratePathProperty="true" Condition="'$(OS)'=='Windows_NT'">
+				<PrivateAssets>all</PrivateAssets>
+				<IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+			</PackageReference>
+		</ItemGroup>
+		<PropertyGroup>
+			<VSWhereDir Condition="'$(Pkgvswhere)'!=''">>$(Pkgvswhere)\tools</VSWhereDir>
+			<!--<VSWhereDir Condition="'$(Pkgvswhere)'==''">>$(NuGetPackageRoot)TODO\tools</VSWhereDir>-->
+		</PropertyGroup>
+		<Exec Command="$(VSWhereDir)\vswhere -latest -products * -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 -property installationPath" ConsoleToMSBuild="true" Condition="'$(OS)'=='Windows_NT'">
 			<Output TaskParameter="ConsoleOutput" PropertyName="VSInstallDir" />
 		</Exec>
 	</Target>
 
-	<Target Name="GenerateKernelCs" Inputs="@(KernelInputs)" Outputs="@(KernelOutputs)" DependsOnTargets="SetVSInstallLocation">
+	<Target Name="GenerateKernelCs" Inputs="@(KernelInputs)" Outputs="@(KernelOutputs)" DependsOnTargets="SetVSInstallDir">
 		<!-- Call the IdlImp task from SIL.LCModel.Build.Tasks in a separate msbuild process,
 		     so it doesn't lock the SIL.LCModel.Build.Tasks.dll in VS. -->
 		<Exec Command="$(MsbuildCommand) GenerateKernelCs.proj /p:OutDir=$(OutDir) /p:IntermediateOutputPath=$(IntermediateOutputPath) /p:Platform=$(Platform) /p:VSInstallDir=&quot;$(VSInstallDir)&quot;" />

--- a/src/SIL.LCModel.Core/Cellar/GenDate.cs
+++ b/src/SIL.LCModel.Core/Cellar/GenDate.cs
@@ -48,7 +48,9 @@ namespace SIL.LCModel.Core.Cellar
 		/// The minimum day value.
 		/// </summary>
 		public const int MinDay = 1;
-
+		/// <summary>
+		/// An arbitrary leap year. Used to validate dates whose year is unknown, making Feb 29 valid.
+		/// </summary>
 		private const int LeapYear = 2008;
 
 		/// <summary>

--- a/src/SIL.LCModel.Core/SIL.LCModel.Core.csproj
+++ b/src/SIL.LCModel.Core/SIL.LCModel.Core.csproj
@@ -1,6 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="14.0" DefaultTargets="Build">
-  <Import Project="..\..\packages\vswhere.2.4.1\build\vswhere.props" Condition="Exists('..\..\packages\vswhere.2.4.1\build\vswhere.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>

--- a/src/SIL.LCModel.Core/packages.config
+++ b/src/SIL.LCModel.Core/packages.config
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="icu.net" version="2.5.4" targetFramework="net461" />
   <package id="Icu4c.Win.Fw.Bin" version="54.1.13-beta" targetFramework="net461" />
@@ -9,4 +9,5 @@
   <package id="NHunspell" version="1.2.5554.16953" targetFramework="net461" />
   <package id="System.Runtime.InteropServices.RuntimeInformation" version="4.3.0" targetFramework="net461" />
   <package id="System.ValueTuple" version="4.5.0" targetFramework="net461" />
+  <package id="vswhere" version="2.4.1" targetFramework="net461" developmentDependency="true" />
 </packages>

--- a/src/SIL.LCModel.Core/packages.config
+++ b/src/SIL.LCModel.Core/packages.config
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="icu.net" version="2.5.4" targetFramework="net461" />
   <package id="Icu4c.Win.Fw.Bin" version="54.1.13-beta" targetFramework="net461" />
@@ -9,5 +9,4 @@
   <package id="NHunspell" version="1.2.5554.16953" targetFramework="net461" />
   <package id="System.Runtime.InteropServices.RuntimeInformation" version="4.3.0" targetFramework="net461" />
   <package id="System.ValueTuple" version="4.5.0" targetFramework="net461" />
-  <package id="vswhere" version="2.4.1" targetFramework="net461" developmentDependency="true" />
 </packages>

--- a/src/SIL.LCModel/Application/ApplicationServices/AppStrings.resx
+++ b/src/SIL.LCModel/Application/ApplicationServices/AppStrings.resx
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <root>
   <!-- 
     Microsoft ResX Schema 
@@ -149,9 +149,11 @@
   </data>
   <data name="ksCannotResolveCrossRef" xml:space="preserve">
     <value>Info: Cannot resolve a link for a cross reference from "{0}" to "{1}".</value>
+    <comment>This message is shown when importing data. One of the entries or senses in a cross reference is missing, so the link cannot be resolved.</comment>
   </data>
   <data name="ksCannotResolveLexRelation" xml:space="preserve">
     <value>Info: Cannot resolve a link for a lexical relation from "{0}" to "{1}".</value>
+    <comment>This message is shown when importing data. One of the entries or senses in a lexical relation is missing, so the link cannot be resolved.</comment>
   </data>
   <data name="ksCreatingWritingSystem" xml:space="preserve">
     <value>Info: Creating new writing system for "{0}".</value>
@@ -224,9 +226,11 @@
   </data>
   <data name="ksExpectedGenDate" xml:space="preserve">
     <value>Warning: Expected &lt;GenDate val="..."/&gt; here.</value>
+    <comment>GenDate (Generic Date) is a type of data. It can store vague dates whose day, month, or year may not be known.</comment>
   </data>
   <data name="ksMissingGenDateVal" xml:space="preserve">
     <value>Warning: Need explicit val attribute for GenDate elements!</value>
+    <comment>GenDate (Generic Date) is a type of data. It can store vague dates whose day, month, or year may not be known.</comment>
   </data>
   <data name="ksExpectedBinary" xml:space="preserve">
     <value>Warning: Expected &lt;Binary&gt;...&lt;/Binary&gt; here.</value>
@@ -311,5 +315,6 @@
   </data>
   <data name="ksNotCreatedForShowSubentryUnderLink" xml:space="preserve">
     <value>{0}: Could not create Show Subentry Under link to entry "{1}", because it does not exist.</value>
+    <comment>Shown during import. The current entry is supposed to be shown as a subentry under "{1}".</comment>
   </data>
 </root>

--- a/src/SIL.LCModel/Templates/GOLDEtic.xml
+++ b/src/SIL.LCModel/Templates/GOLDEtic.xml
@@ -199,7 +199,7 @@
 		 <def ws="fa"/>
 		 <def ws="ru">Классификатор - это часть речи, члены которой выражают классификацию существительного.</def>
 		 <def ws="id"/>
-		 <citation ws="en">Cryustal 1997:61</citation>
+		 <citation ws="en">Crystal 1997:61</citation>
 		 <citation ws="en">Mish et al. 1990:246</citation>
 		 <citation ws="en">Payne 1997:107</citation>
 	  </item>
@@ -392,7 +392,7 @@
 			<def ws="fa"/>
 			<def ws="ru">Относительный союз - это союз, который связывает относительное придаточное с главным словом. Его следует отличать от относительного местоимения, тем что он не имеет номинативную функцию внутри относительного придаточного.</def>
 			<def ws="id"/>
-			<citation ws="en">Payne1997:332</citation>
+			<citation ws="en">Payne 1997:332</citation>
 		 </item>
 	  </item>
    </item>
@@ -1107,7 +1107,7 @@
 	  <def ws="fa"/>
 	  <def ws="ru"/>
 	  <def ws="id"/>
-	  <citation ws="en">Valentine 2001: 152-154</citation>
+	  <citation ws="en">Valentine 2001:152-154</citation>
    </item>
    <item type="category" id="Preverb" guid="4e676ad2-542d-461d-9d78-1dbcb55ec456">
 	  <abbrev ws="en">preverb</abbrev>
@@ -1134,7 +1134,7 @@
 	  <def ws="fa"/>
 	  <def ws="ru"/>
 	  <def ws="id"/>
-	  <citation ws="en">Valentine 2001: 154-158</citation>
+	  <citation ws="en">Valentine 2001:154-158</citation>
    </item>
    <item type="category" id="Pro-form" guid="a4fc78d6-7591-4fb3-8edd-82f10ae3739d">
 	  <abbrev ws="en">pro-form</abbrev>


### PR DESCRIPTION
Put the path to vswhere in a file that always exists.

When Visual Studio is started from a clean repository,
SIL.LCModel.Core.csproj doesn't load the not-yet-existent vswhere.props.
Builds from the build menu eventually succeed, but VS couldn't build and
run unit tests until it was restarted.
With this change, the pre-test build should succeed on the first try.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="24" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/liblcm/130)
<!-- Reviewable:end -->
