### PR TITLE
Fix crash shutting down

### DIFF
--- a/src/SIL.LCModel/Infrastructure/Impl/SharedXMLBackendProvider.cs
+++ b/src/SIL.LCModel/Infrastructure/Impl/SharedXMLBackendProvider.cs
@@ -54,6 +54,10 @@ namespace SIL.LCModel.Infrastructure.Impl
 		{
 			get
 			{
+				// can happen when shutting down, e.g. after getting an exception
+				if (m_commitLogMutex == null)
+					return -1;
+
 				using (m_commitLogMutex.Lock())
 				{
 					using (MemoryMappedViewStream stream = m_commitLogMetadata.CreateViewStream())
@@ -338,6 +342,10 @@ namespace SIL.LCModel.Infrastructure.Impl
 
 		internal override void LockProject()
 		{
+			// can happen when shutting down, e.g. after getting an exception
+			if (m_commitLogMutex == null)
+				return;
+
 			using (m_commitLogMutex.Lock())
 			{
 				base.LockProject();
@@ -355,6 +363,10 @@ namespace SIL.LCModel.Infrastructure.Impl
 
 		internal override void UnlockProject()
 		{
+			// can happen when shutting down, e.g. after getting an exception
+			if (m_commitLogMutex == null)
+				return;
+
 			using (m_commitLogMutex.Lock())
 			{
 				base.UnlockProject();
@@ -375,6 +387,10 @@ namespace SIL.LCModel.Infrastructure.Impl
 
 		public override bool Commit(HashSet<ICmObjectOrSurrogate> newbies, HashSet<ICmObjectOrSurrogate> dirtballs, HashSet<ICmObjectId> goners)
 		{
+			// can happen when shutting down, e.g. after getting an exception
+			if (m_commitLogMutex == null)
+				return true;
+
 			using (m_commitLogMutex.Lock())
 			{
 				CommitLogMetadata metadata;
@@ -488,6 +504,10 @@ namespace SIL.LCModel.Infrastructure.Impl
 
 		protected override void WriteCommitWork(CommitWork workItem)
 		{
+			// can happen when shutting down, e.g. after getting an exception
+			if (m_commitLogMutex == null)
+				return;
+
 			using (m_commitLogMutex.Lock())
 			{
 				base.WriteCommitWork(workItem);


### PR DESCRIPTION
This change fixes a crash that we got in FW after we got another exception and displayed a green screen and the user clicked ok. In that case `ShutdownInteral()` got called before we called `Commit()`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/liblcm/155)
<!-- Reviewable:end -->
