### PR TITLE
Don't automatically copy files from Icu4c

### DIFF
--- a/tests/SIL.LCModel.Core.Tests/SIL.LCModel.Core.Tests.csproj
+++ b/tests/SIL.LCModel.Core.Tests/SIL.LCModel.Core.Tests.csproj
@@ -32,7 +32,7 @@ See full changelog at https://github.com/sillsdev/liblcm/blob/feature/nuget/CHAN
 
   <ItemGroup>
     <PackageReference Include="GitVersionTask" Version="5.3.4" PrivateAssets="All" />
-    <PackageReference Include="Icu4c.Win.Min" Version="62.2.1-beta" />
+    <PackageReference Include="Icu4c.Win.Min" Version="62.2.1-beta" IncludeAssets="build" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
     <PackageReference Include="SIL.ReleaseTasks" Version="2.3.4" PrivateAssets="All" />
     <PackageReference Include="SIL.TestUtilities" Version="8.0.0-beta0166" />


### PR DESCRIPTION
This change prevents the dlls from Icu4c.Win.Min to automatically get copied to the output directory when a client consumes the
SIL.LCModel.Core.Tests nuget package.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/liblcm/167)
<!-- Reviewable:end -->
