### PR TITLE
Improve error message for InvalidStructureException

### DIFF
--- a/lib/teamcity.dep
+++ b/lib/teamcity.dep
@@ -8,8 +8,8 @@ Url=http://build.palaso.org
 
 [TC::Libpalaso_PalasoWinmasterContinuous]
 Name=palaso-win-master Continuous
-RevisionName=lastSuccessful
-RevisionValue=latest.lastSuccessful
+RevisionName=safe_tag
+RevisionValue=fw-9.1.1.tcbuildtag
 Condition=Win64
 Path=SIL.Core.dll => downloads/
 SIL.Core.pdb => downloads/
@@ -25,8 +25,8 @@ Spart.dll => downloads/
 
 [TC::Libpalaso_PalasoLinux64masterContinuous]
 Name=palaso-linux64-master Continuous
-RevisionName=lastSuccessful
-RevisionValue=latest.lastSuccessful
+RevisionName=safe_tag
+RevisionValue=fw-9.1.1.tcbuildtag
 Condition=Linux
 Path=SIL.Core.dll => downloads/
 SIL.Core.dll.mdb => downloads/
@@ -42,8 +42,8 @@ Spart.dll => downloads/
 
 [TC::Libpalaso_PalasoWin32masterContinuous]
 Name=palaso-win32-master Continuous
-RevisionName=lastSuccessful
-RevisionValue=latest.lastSuccessful
+RevisionName=safe_tag
+RevisionValue=fw-9.1.1.tcbuildtag
 Condition=Win32
 Path=SIL.Core.dll => downloads/
 SIL.Core.pdb => downloads/

--- a/src/SIL.LCModel/Exceptions.cs
+++ b/src/SIL.LCModel/Exceptions.cs
@@ -255,20 +255,15 @@ namespace SIL.LCModel
 	/// ----------------------------------------------------------------------------------------
 	public class InvalidStructureException : Exception
 	{
-		private string m_styleName;
-		private StructureValues m_expectedStructure;
-
 		/// ------------------------------------------------------------------------------------
-		/// <summary>
-		/// C'tor
-		/// </summary>
+		/// <summary/>
 		/// <param name="styleName">Name of style</param>
-		/// <param name="expectedStructure">Info about the run</param>
+		/// <param name="expectedStructure">The structure which the paragraph style should have matched</param>
 		/// ------------------------------------------------------------------------------------
 		public InvalidStructureException(string styleName, StructureValues expectedStructure)
 		{
-			m_styleName = styleName;
-			m_expectedStructure = expectedStructure;
+			StyleName = styleName;
+			ExpectedStructure = expectedStructure;
 		}
 
 		/// ------------------------------------------------------------------------------------
@@ -276,20 +271,17 @@ namespace SIL.LCModel
 		/// Gets the name of the style which is invalid for the expected structure.
 		/// </summary>
 		/// ------------------------------------------------------------------------------------
-		public string StyleName
-		{
-			get { return m_styleName; }
-		}
+		public string StyleName { get; }
 
 		/// ------------------------------------------------------------------------------------
 		/// <summary>
 		/// Gets the expected structure (either heading or body).
 		/// </summary>
 		/// ------------------------------------------------------------------------------------
-		public StructureValues ExpectedStructure
-		{
-			get { return m_expectedStructure; }
-		}
+		public StructureValues ExpectedStructure { get; }
+
+		public override string Message => $"Structure in style '{StyleName}' did not match the expected structure of " +
+		                                  $"'{Enum.GetName(typeof(StructureValues), ExpectedStructure)}'";
 	}
 	#endregion
 

--- a/tests/SIL.LCModel.Tests/DomainImpl/ScrSectionTests.cs
+++ b/tests/SIL.LCModel.Tests/DomainImpl/ScrSectionTests.cs
@@ -922,6 +922,24 @@ namespace SIL.LCModel.DomainImpl
 		}
 		#endregion
 
+		/// ------------------------------------------------------------------------------------
+		/// <summary>
+		/// Tests MoveHeadingParasToContent when changing a heading paragraph to a content
+		/// paragraph at the beginning of a section.
+		/// </summary>
+		/// ------------------------------------------------------------------------------------
+		[Test]
+		public void InvalidStructureExceptionMessage()
+		{
+			IScrSection introSection1 = m_philemon[0];
+			Assert.AreEqual(1, introSection1.ContentOA.ParagraphsOS.Count);
+
+			// Move first content paragraph to a heading paragraph.
+			var invalidHeadingStyle = Cache.LangProject.FindStyle(ScrStyleNames.FootnoteMarker);
+			var result = Assert.Throws<InvalidStructureException>(()=> introSection1.MoveHeadingParasToContent(0, invalidHeadingStyle));
+			Assert.That(result.Message, Is.StringContaining(ScrStyleNames.FootnoteMarker));
+		}
+
 		#region MoveContentParasToHeading
 		/// ------------------------------------------------------------------------------------
 		/// <summary>


### PR DESCRIPTION
* Add the style name that doesn't match the structure type
  as well as the expected StructureType to the exception
  Message

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/liblcm/171)
<!-- Reviewable:end -->
