### PR TITLE
LT-20408: Allow adding valid characters with diacritics

### DIFF
--- a/LCM.sln.DotSettings
+++ b/LCM.sln.DotSettings
@@ -3,6 +3,7 @@
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Charis/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Duolos/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=flid/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=LGPL/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=ownerless/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Subentry/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=subrecords/@EntryIndexedValue">True</s:Boolean>

--- a/src/SIL.LCModel.Core/Text/CustomIcu.cs
+++ b/src/SIL.LCModel.Core/Text/CustomIcu.cs
@@ -357,7 +357,7 @@ namespace SIL.LCModel.Core.Text
 		public static UcdProperty GetCombiningClassInfo(int characterCode)
 		{
 			var normalizer = GetIcuNormalizer(FwNormalizationMode.knmNFC);
-			return UcdProperty.GetInstance(normalizer.GetCombiningClass(characterCode));
+			return UcdProperty.GetInstance((byte)normalizer.GetCombiningClass(characterCode));
 		}
 
 		/// ------------------------------------------------------------------------------------

--- a/tests/SIL.LCModel.Core.Tests/Text/CustomIcuTests.cs
+++ b/tests/SIL.LCModel.Core.Tests/Text/CustomIcuTests.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2009-2018 SIL International
+// Copyright (c) 2009-2021 SIL International
 // This software is licensed under the LGPL, version 2.1 or later
 // (http://www.gnu.org/licenses/lgpl-2.1.html)
 
@@ -120,6 +120,15 @@ namespace SIL.LCModel.Core.Text
 				breakIterator.SetText(text);
 				return breakIterator;
 			}
+		}
+
+		[TestCase('a', 0)]
+		[TestCase(769, 0xE6)]
+		public void GetCombiningClassInfo(int characterCode, int combiningClass)
+		{
+			var expected = UcdProperty.GetInstance(combiningClass);
+			var result = CustomIcu.GetCombiningClassInfo(characterCode);
+			Assert.AreEqual(expected, result);
 		}
 
 		/// ------------------------------------------------------------------------------------


### PR DESCRIPTION
* Cast the return type of Normalizer2.GetCombiningClass to byte.
This will have to do until we can upgrade to the latest version
of ICU.NET, which has the proper return type.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/liblcm/180)
<!-- Reviewable:end -->
