### PR TITLE
Feature/lt 20415

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,3 +50,18 @@ Tests
 Linux
 
     (. environ && cd artifacts/Debug/ && ICU_DATA="IcuData/" nunit-console SIL.LCModel*Tests.dll )
+
+Windows with ReSharper
+	Open the solution in Visual Studio and run them all there. Right-click the solution and choose Run Unit Tests.
+
+Windows without ReSharper
+	To run the tests for a single test dll:
+	1. Go to the liblcm directory.
+	2. Execute: "C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\MSBuild\15.0\Bin\msbuild.exe"
+	   Note: Running the tests after building the solution from inside VS resulted in a BadImageFormatException.
+	         Running the tests after building from the cmd prompt worked.
+	3. Go to the liblcm\artifacts\Debug directory.
+	4. Execute: "..\..\packages\NUnit.ConsoleRunner.3.9.0\tools\nunit3-console.exe" SIL.LCModel.Tests.dll
+	   (Or specify one of the other SIL.LCModel*Tests.dll)
+	5. To debug the tests from Visual Studio; Immediately after the tests have started
+	   running "Attach to Process..." and select 'nunit-agent.exe'.

--- a/README.md
+++ b/README.md
@@ -47,14 +47,16 @@ Build a 64-bit build with the command:
 Tests
 -----
 
-Linux
+**On Linux**
 
     (. environ && cd artifacts/Debug/ && ICU_DATA="IcuData/" nunit-console SIL.LCModel*Tests.dll )
 
-Windows with ReSharper
+**On Windows with ReSharper**
+
 	Open the solution in Visual Studio and run them all there. Right-click the solution and choose Run Unit Tests.
 
-Windows without ReSharper
+**On Windows without ReSharper**
+
 	To run the tests for a single test dll:
 	1. Go to the liblcm directory.
 	2. Execute: "C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\MSBuild\15.0\Bin\msbuild.exe"

--- a/src/SIL.LCModel/Infrastructure/Impl/RepositoryAdditions.cs
+++ b/src/SIL.LCModel/Infrastructure/Impl/RepositoryAdditions.cs
@@ -366,7 +366,19 @@ namespace SIL.LCModel.Infrastructure.Impl
 		/// </summary>
 		public IEnumerable<IConstituentChartCellPart> InstancesWithChartCellColumn(ICmPossibility target)
 		{
-			return AllInstances().Where(cccp => cccp.ColumnRA == target);
+			((ICmObjectRepositoryInternal)m_cache.ServiceLocator.ObjectRepository).EnsureCompleteIncomingRefsFrom(
+				ConstituentChartCellPartTags.kflidColumn);
+			SimpleBag<ICmObject> chartCells = new SimpleBag<ICmObject>();
+			foreach (IReferenceSource referrer in target.ReferringObjects)
+			{
+				if ((referrer as CmObject).ClassID != 5123 /* "DsConstChart" */)
+				{
+					if (referrer.RefersTo(target, ConstituentChartCellPartTags.kflidColumn))
+						chartCells.Add(referrer.Source);
+				}
+			}
+
+			return chartCells.Distinct().Cast<IConstituentChartCellPart>();
 		}
 	}
 	#endregion

--- a/tests/SIL.LCModel.Tests/Infrastructure/Impl/RepositoryTests.cs
+++ b/tests/SIL.LCModel.Tests/Infrastructure/Impl/RepositoryTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2009-2013 SIL International
+// Copyright (c) 2009-2013 SIL International
 // This software is licensed under the LGPL, version 2.1 or later
 // (http://www.gnu.org/licenses/lgpl-2.1.html)
 //
@@ -260,6 +260,40 @@ namespace SIL.LCModel.Infrastructure.Impl
 		}
 	}
 
+	#region ConstituentChartCellPartRepository Tests
+	/// ----------------------------------------------------------------------------------------
+	/// <summary>
+	/// Class to test additions to ConstituentChartCellPartRepository functionality.
+	/// </summary>
+	/// ----------------------------------------------------------------------------------------
+	[TestFixture]
+	public class ConstituentChartCellPartRepositoryTests : MemoryOnlyBackendProviderRestoredForEachTestTestBase
+	{
+		/// <summary>
+		/// Test InstancesWithChartCellColumn
+		/// </summary>
+		[Test]
+		public void InstancesWithChartCellColumn()
+		{
+			var repo = (ConstituentChartCellPartRepository)Cache.ServiceLocator.GetInstance<IConstituentChartCellPartRepository>();
+			ICmPossibility template = Cache.LangProject.GetDefaultChartTemplate();
+			IDsConstChart chart = SetupChart(template);  // This DOES add the chart as a reference to the template.
+
+			IEnumerable<IConstituentChartCellPart> chartCells = repo.InstancesWithChartCellColumn(template);
+			Assert.AreEqual(1, template.ReferringObjects.Count(), "The chart should be included as a referring object");
+			Assert.AreEqual(0, chartCells.Count(), "The chart should not be included as a chart cell");
+		}
+
+		private IDsConstChart SetupChart(ICmPossibility template)
+		{
+			var servLoc = Cache.ServiceLocator;
+			var text = servLoc.GetInstance<ITextFactory>().Create();
+			var stText = servLoc.GetInstance<IStTextFactory>().Create();
+			text.ContentsOA = stText;
+			return servLoc.GetInstance<IDsConstChartFactory>().Create(Cache.LangProject.DiscourseDataOA, stText, template);
+		}
+	}
+	#endregion
 
 	#region PunctuationFormRepository Tests
 	/// ----------------------------------------------------------------------------------------


### PR DESCRIPTION
LT-20415: Do not include the chart in the collection of chart cells

When returning a collection of chart cells that are identified by a
column, we no longer return the chart in the collection.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/liblcm/193)
<!-- Reviewable:end -->
