### PR TITLE
[API] Add FileUtils methods to enumerate directories

### DIFF
--- a/LCM.sln.DotSettings
+++ b/LCM.sln.DotSettings
@@ -1,4 +1,6 @@
 ﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
+	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=IO/@EntryIndexedValue">IO</s:String>
+	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=OS/@EntryIndexedValue">OS</s:String>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=analyses/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Charis/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Duolos/@EntryIndexedValue">True</s:Boolean>
@@ -6,4 +8,5 @@
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=ownerless/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Subentry/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=subrecords/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=unrooted/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=wordform/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>

--- a/src/SIL.LCModel.Core/SIL.LCModel.Core.csproj
+++ b/src/SIL.LCModel.Core/SIL.LCModel.Core.csproj
@@ -38,8 +38,8 @@ See full changelog at https://github.com/sillsdev/liblcm/blob/develop/CHANGELOG.
     <PackageReference Include="Microsoft.Extensions.DependencyModel" Version="2.0.4" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
     <PackageReference Include="NHunspell.Patched" Version="1.2.5554" />
-    <PackageReference Include="SIL.Core.Desktop" Version="8.0.0-*" />
-    <PackageReference Include="SIL.Lexicon" Version="8.0.0-*" />
+    <PackageReference Include="SIL.Core.Desktop" Version="9.0.0-*" />
+    <PackageReference Include="SIL.Lexicon" Version="9.0.0-*" />
     <PackageReference Include="SIL.ReleaseTasks" Version="2.5.0" PrivateAssets="All" />
     <PackageReference Include="System.Runtime.InteropServices.RuntimeInformation" Version="4.3.0" />
     <PackageReference Include="System.ValueTuple" Version="4.5.0" />

--- a/src/SIL.LCModel.Utils/FileUtils.cs
+++ b/src/SIL.LCModel.Utils/FileUtils.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Linq;
 using System.Security;
@@ -67,6 +68,10 @@ namespace SIL.LCModel.Utils
 		/// System.IO.Directory
 		/// </summary>
 		/// ----------------------------------------------------------------------------------------
+		[SuppressMessage("ReSharper", "MemberHidesStaticFromOuterClass",
+			Justification = "This class contains implementations of proxy methods in the outer class.")]
+		[SuppressMessage("CodeQuality", "IDE0079:Remove unnecessary suppression",
+			Justification = "ReSharper.MemberHidesStaticFromOuterClass was deemed unnecessary.")]
 		private class SystemIOAdapter : IFileOS
 		{
 			/// ------------------------------------------------------------------------------------
@@ -117,6 +122,16 @@ namespace SIL.LCModel.Utils
 			public string[] GetFilesInDirectory(string sPath, string searchPattern)
 			{
 				return Directory.GetFiles(sPath, searchPattern);
+			}
+
+			public string[] GetDirectoriesInDirectory(string sPath)
+			{
+				return Directory.GetDirectories(sPath);
+			}
+
+			public string[] GetDirectoriesInDirectory(string sPath, string searchPattern)
+			{
+				return Directory.GetDirectories(sPath, searchPattern);
 			}
 
 			/// ------------------------------------------------------------------------------------
@@ -389,6 +404,25 @@ namespace SIL.LCModel.Utils
 			return s_fileos.GetFilesInDirectory(sPath, searchPattern);
 		}
 
+		/// <summary>
+		/// Gets the directories in the given directory.
+		/// </summary>
+		/// <param name="sPath">The directory path.</param>
+		/// <returns>list of directories</returns>
+		public static string[] GetDirectoriesInDirectory(string sPath) => s_fileos.GetDirectoriesInDirectory(sPath);
+
+		/// <summary>
+		/// Gets the directories in the given directory.
+		/// </summary>
+		/// <param name="sPath">The directory path.</param>
+		/// <param name="searchPattern">The search string to match against the names of directories
+		/// in sPath. The parameter cannot end in two periods ("..") or contain two periods ("..")
+		/// followed by DirectorySeparatorChar or AltDirectorySeparatorChar, nor can it contain
+		/// any of the characters in InvalidPathChars.</param>
+		/// <returns>list of directories</returns>
+		public static string[] GetDirectoriesInDirectory(string sPath, string searchPattern) =>
+			s_fileos.GetDirectoriesInDirectory(sPath, searchPattern);
+
 		/// ------------------------------------------------------------------------------------
 		/// <summary>
 		/// Try to match the given pathname to an existing file, playing whatever games are
@@ -568,6 +602,9 @@ namespace SIL.LCModel.Utils
 			return s_fileos.OpenStreamForWrite(filename, FileMode.Open);
 		}
 
+		[Obsolete("Use WriteStringToFile")]
+		public static void WriteStringtoFile(string filename, string contents, Encoding encoding) => WriteStringToFile(filename, contents, encoding);
+
 		/// ------------------------------------------------------------------------------------
 		/// <summary>
 		/// Writes the string to file.
@@ -576,7 +613,7 @@ namespace SIL.LCModel.Utils
 		/// <param name="contents">The contents to write to the file.</param>
 		/// <param name="encoding">The encoding.</param>
 		/// ------------------------------------------------------------------------------------
-		public static void WriteStringtoFile(string filename, string contents, Encoding encoding)
+		public static void WriteStringToFile(string filename, string contents, Encoding encoding)
 		{
 			using (TextWriter write = OpenFileForWrite(filename, encoding))
 			{
@@ -696,7 +733,7 @@ namespace SIL.LCModel.Utils
 			if (DirectoryExists(directory))
 				return true;
 
-			// Attempt to create the directoy if it doesn't exist yet.
+			// Attempt to create the directory if it doesn't exist yet.
 			try
 			{
 				s_fileos.CreateDirectory(directory);

--- a/src/SIL.LCModel.Utils/IFileOS.cs
+++ b/src/SIL.LCModel.Utils/IFileOS.cs
@@ -54,6 +54,28 @@ namespace SIL.LCModel.Utils
 
 		/// ------------------------------------------------------------------------------------
 		/// <summary>
+		/// Gets the directories in the given directory.
+		/// </summary>
+		/// <param name="sPath">The directory path.</param>
+		/// <returns>list of directories</returns>
+		/// ------------------------------------------------------------------------------------
+		string[] GetDirectoriesInDirectory(string sPath);
+
+		/// ------------------------------------------------------------------------------------
+		/// <summary>
+		/// Gets the directories in the given directory.
+		/// </summary>
+		/// <param name="sPath">The directory path.</param>
+		/// <param name="searchPattern">The search string to match against the names of directories in
+		/// path. The parameter cannot end in two periods ("..") or contain two periods ("..")
+		/// followed by DirectorySeparatorChar or AltDirectorySeparatorChar, nor can it contain
+		/// any of the characters in InvalidPathChars.</param>
+		/// <returns>list of directories</returns>
+		/// ------------------------------------------------------------------------------------
+		string[] GetDirectoriesInDirectory(string sPath, string searchPattern);
+
+		/// ------------------------------------------------------------------------------------
+		/// <summary>
 		/// Gets the writer.
 		/// </summary>
 		/// <param name="filename">The filename.</param>

--- a/src/SIL.LCModel.Utils/SIL.LCModel.Utils.csproj
+++ b/src/SIL.LCModel.Utils/SIL.LCModel.Utils.csproj
@@ -32,7 +32,7 @@ See full changelog at https://github.com/sillsdev/liblcm/blob/develop/CHANGELOG.
   <ItemGroup>
     <PackageReference Include="GitVersion.MsBuild" Version="5.6.10" PrivateAssets="All" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
-    <PackageReference Include="SIL.Core" Version="8.0.0-*" />
+    <PackageReference Include="SIL.Core" Version="9.0.0-*" />
     <PackageReference Include="SIL.ReleaseTasks" Version="2.5.0" PrivateAssets="All" />
     <PackageReference Include="Mono.Posix" Version="5.4.0.201" PrivateAssets="All" Condition="'$(OS)' == 'Windows_NT'" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />

--- a/tests/SIL.LCModel.Core.Tests/SIL.LCModel.Core.Tests.csproj
+++ b/tests/SIL.LCModel.Core.Tests/SIL.LCModel.Core.Tests.csproj
@@ -36,7 +36,7 @@ See full changelog at https://github.com/sillsdev/liblcm/blob/develop/CHANGELOG.
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
     <PackageReference Include="NUnit" Version="3.13.0" />
     <PackageReference Include="SIL.ReleaseTasks" Version="2.5.0" PrivateAssets="All" />
-    <PackageReference Include="SIL.TestUtilities" Version="8.0.0-*" />
+    <PackageReference Include="SIL.TestUtilities" Version="9.0.0-*" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
* Add containing directories when adding a directory to MockFileOS
* Add MockFileOS.ReadAllText(filename)
* Correct capitalization of FileUtils.WriteStringToFile
* Upgrade to Palaso 9.0

+semver:minor

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/liblcm/197)
<!-- Reviewable:end -->
