### PR TITLE
Remove affix markers when Headword uses Citation Form

### DIFF
--- a/src/SIL.LCModel/DomainServices/StringServices.cs
+++ b/src/SIL.LCModel/DomainServices/StringServices.cs
@@ -292,6 +292,11 @@ namespace SIL.LCModel.DomainServices
 				InsertHomographNumber(tisb, nHomograph, hc, hv, cache);
 		}
 
+		private static bool NeedsAffixDecorations(ILexEntry entry, ILgWritingSystem ws)
+		{
+			return !IsAudioWritingSystem(ws) && string.IsNullOrEmpty(entry.CitationForm.get_String(ws.Handle).Text);
+		}
+
 		private static bool IsAudioWritingSystem(ILgWritingSystem ws)
 		{
 			return ws != null &&
@@ -501,7 +506,7 @@ namespace SIL.LCModel.DomainServices
 				return "";
 			// Audio writing systems actually store a filename as the contents. Do not corrupt it with affix markers.
 			var ws = entry.Cache?.WritingSystemFactory?.get_EngineOrNull(wsVern);
-			return IsAudioWritingSystem(ws) ? form : DecorateFormWithAffixMarkers(entry, form);
+			return NeedsAffixDecorations(entry, ws) ? DecorateFormWithAffixMarkers(entry, form) : form;
 		}
 
 		internal static string DecorateFormWithAffixMarkers(ILexEntry entry, string form)

--- a/tests/SIL.LCModel.Tests/DomainImpl/LexEntryTests.cs
+++ b/tests/SIL.LCModel.Tests/DomainImpl/LexEntryTests.cs
@@ -83,19 +83,26 @@ namespace SIL.LCModel.DomainImpl
 		{
 			LexEntry bank1 = null;
 			LexEntry past = null;
+			LexEntry agent = null;
 			UndoableUnitOfWorkHelper.Do("doit", "undoit", Cache.ActionHandlerAccessor,
 				() =>
 				{
 					bank1 = (LexEntry)MakeEntryWithForm("bank");
 					past = (LexEntry)MakeAffixWithForm("ed", MoMorphTypeTags.kguidMorphSuffix);
+					// set Citation form on 'er' suffix to set up verification of Citation behavior
+					agent = (LexEntry)MakeAffixWithForm("er", MoMorphTypeTags.kguidMorphSuffix);
+					agent.CitationForm.set_String(Cache.DefaultVernWs, "er");
 					var pos1 = MakePartOfSpeech();
 					MakeAffixMsa(past, pos1, pos1);
 				});
 			Assert.That(bank1.MLHeadWord.VernacularDefaultWritingSystem.Text, Is.EqualTo("bank"));
 			Assert.That(past.MLHeadWord.VernacularDefaultWritingSystem.Text, Is.EqualTo("-ed"));
+			// The presence of a Citation form on agent should result in no suffix marker in the MLHeadword (LT-20704)
+			Assert.That(agent.MLHeadWord.VernacularDefaultWritingSystem.Text, Is.EqualTo("er"));
 			Assert.That(bank1.MLHeadWord.AnalysisDefaultWritingSystem.Text, Is.Null);
 			Assert.That(past.MLHeadWord.AnalysisDefaultWritingSystem.Text, Is.Null,
 				"where all forms are empty, no affix marker");
+
 			UndoableUnitOfWorkHelper.Do("doit", "undoit", Cache.ActionHandlerAccessor,
 				() =>
 				{


### PR DESCRIPTION
* Should satisfy requirements of LT-20704

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/liblcm/198)
<!-- Reviewable:end -->
