### PR TITLE
LT-20662: Fix crash adding a new custom field to Analyze

### DIFF
--- a/src/SIL.LCModel/DomainImpl/Strings.cs
+++ b/src/SIL.LCModel/DomainImpl/Strings.cs
@@ -293,8 +293,13 @@ namespace SIL.LCModel.DomainImpl
 		private ITsString GetBest(int ws)
 		{
 			var bestWs = WritingSystemServices.ActualWs(m_object.Cache, ws, m_object.Hvo, m_flid);
-			return (bestWs == 0 ? null : get_String(bestWs)) ??
-				   TsStringUtils.MakeString(Strings.ksStars, m_object.Cache.WritingSystemFactory.UserWs);
+			ITsString retStr = null;
+			if (bestWs != 0)
+				retStr = get_String(bestWs);
+			if(bestWs == 0 || retStr == null || retStr.Text == null)
+				retStr = TsStringUtils.MakeString(Strings.ksStars, m_object.Cache.WritingSystemFactory.UserWs);
+
+			return retStr;
 		}
 	}
 

--- a/src/SIL.LCModel/DomainServices/WritingSystemServices.cs
+++ b/src/SIL.LCModel/DomainServices/WritingSystemServices.cs
@@ -858,6 +858,11 @@ namespace SIL.LCModel.DomainServices
 							break;
 						}
 					}
+
+					// If we still have a zero for the retWs then return the default.
+					if (retWs == 0)
+						retWs = defaultAnalWs;
+
 					break;
 				case kwsFirstVernOrNamed:
 				case kwsFirstVern:
@@ -907,6 +912,11 @@ namespace SIL.LCModel.DomainServices
 							break;
 						}
 					}
+
+					// If we still have a zero for the retWs then return the default.
+					if (retWs == 0)
+						retWs = defaultVernWs;
+
 					break;
 				case kwsFirstAnalOrVern:
 					if (flid == 0) // sometimes used this way, just trying for a ws...make robust

--- a/tests/SIL.LCModel.Tests/DomainServices/WritingSystemServicesTests.cs
+++ b/tests/SIL.LCModel.Tests/DomainServices/WritingSystemServicesTests.cs
@@ -44,6 +44,16 @@ namespace SIL.LCModel.DomainServices
 		[Test]
 		public void GetMagicStringAlt_TestFirstAnaly()
 		{
+			int wsId;
+			var entry = Cache.ServiceLocator.GetInstance<ILexEntryFactory>().Create();
+			var sense = Cache.ServiceLocator.GetInstance<ILexSenseFactory>().Create();
+			entry.SensesOS.Add(sense);
+
+			//SUT magic gets the default analysis when there are no others
+			WritingSystemServices.GetMagicStringAlt(Cache, Cache.MainCacheAccessor,
+				WritingSystemServices.kwsFirstAnal, sense.Hvo, sense.Definition.Flid, false, out wsId);
+			Assert.AreEqual(wsId, Cache.DefaultAnalWs, "Did not get the default analysis when there are no others.");
+
 			CoreWritingSystemDefinition frWs;
 			WritingSystemServices.FindOrCreateWritingSystem(Cache, null, "fr", false, false, out frWs);
 			var frId = frWs.Handle;
@@ -57,13 +67,10 @@ namespace SIL.LCModel.DomainServices
 			Cache.LangProject.AddToCurrentAnalysisWritingSystems(frWs);
 			Cache.LangProject.AddToCurrentAnalysisWritingSystems(enWs);
 			Cache.LangProject.AnalysisWritingSystems.Add(ptWs);
-			var entry = Cache.ServiceLocator.GetInstance<ILexEntryFactory>().Create();
-			var sense = Cache.ServiceLocator.GetInstance<ILexSenseFactory>().Create();
-			entry.SensesOS.Add(sense);
 			sense.Definition.set_String(frId, TsStringUtils.MakeString("fr", frId));
 			sense.Definition.set_String(enId, TsStringUtils.MakeString("en", enId));
 			sense.Definition.set_String(ptId, TsStringUtils.MakeString("pt", ptId));
-			int wsId;
+
 			//SUT magic gets first analysis when there is one.
 			WritingSystemServices.GetMagicStringAlt(Cache, Cache.MainCacheAccessor,
 																 WritingSystemServices.kwsFirstAnal, sense.Hvo, sense.Definition.Flid, false, out wsId);
@@ -154,6 +161,14 @@ namespace SIL.LCModel.DomainServices
 		[Test]
 		public void GetMagicStringAlt_TestFirstVern()
 		{
+			int wsId;
+			var entry = Cache.ServiceLocator.GetInstance<ILexEntryFactory>().Create();
+
+			//SUT magic gets the default vernacular when there are no others
+			WritingSystemServices.GetMagicStringAlt(Cache, Cache.MainCacheAccessor,
+				WritingSystemServices.kwsFirstVern, entry.Hvo, entry.CitationForm.Flid, false, out wsId);
+			Assert.AreEqual(wsId, Cache.DefaultVernWs, "Did not get the default vernacular when there are no others.");
+
 			CoreWritingSystemDefinition mluWs;
 			WritingSystemServices.FindOrCreateWritingSystem(Cache, null, "mlu", false, false, out mluWs);
 			var mluId = mluWs.Handle;
@@ -167,11 +182,10 @@ namespace SIL.LCModel.DomainServices
 			Cache.LangProject.AddToCurrentVernacularWritingSystems(mluWs);
 			Cache.LangProject.AddToCurrentVernacularWritingSystems(senWs);
 			Cache.LangProject.VernacularWritingSystems.Add(sekWs);
-			var entry = Cache.ServiceLocator.GetInstance<ILexEntryFactory>().Create();
 			entry.CitationForm.set_String(mluId, TsStringUtils.MakeString("To'abaita", mluId));
 			entry.CitationForm.set_String(senId, TsStringUtils.MakeString("Sena", senId));
 			entry.CitationForm.set_String(sekId, TsStringUtils.MakeString("Sekani", sekId));
-			int wsId;
+
 			//SUT magic gets first vernacular when there is one.
 			WritingSystemServices.GetMagicStringAlt(Cache, Cache.MainCacheAccessor,
 																 WritingSystemServices.kwsFirstVern, entry.Hvo, entry.CitationForm.Flid, false, out wsId);

--- a/tests/SIL.LCModel.Tests/DomainServices/WritingSystemServicesTests.cs
+++ b/tests/SIL.LCModel.Tests/DomainServices/WritingSystemServicesTests.cs
@@ -50,9 +50,10 @@ namespace SIL.LCModel.DomainServices
 			entry.SensesOS.Add(sense);
 
 			//SUT magic gets the default analysis when there are no others
-			WritingSystemServices.GetMagicStringAlt(Cache, Cache.MainCacheAccessor,
+			var retStr = WritingSystemServices.GetMagicStringAlt(Cache, Cache.MainCacheAccessor,
 				WritingSystemServices.kwsFirstAnal, sense.Hvo, sense.Definition.Flid, false, out wsId);
 			Assert.AreEqual(wsId, Cache.DefaultAnalWs, "Did not get the default analysis when there are no others.");
+			Assert.IsTrue(retStr == null || retStr.Text == null);
 
 			CoreWritingSystemDefinition frWs;
 			WritingSystemServices.FindOrCreateWritingSystem(Cache, null, "fr", false, false, out frWs);
@@ -165,9 +166,10 @@ namespace SIL.LCModel.DomainServices
 			var entry = Cache.ServiceLocator.GetInstance<ILexEntryFactory>().Create();
 
 			//SUT magic gets the default vernacular when there are no others
-			WritingSystemServices.GetMagicStringAlt(Cache, Cache.MainCacheAccessor,
+			var retStr = WritingSystemServices.GetMagicStringAlt(Cache, Cache.MainCacheAccessor,
 				WritingSystemServices.kwsFirstVern, entry.Hvo, entry.CitationForm.Flid, false, out wsId);
 			Assert.AreEqual(wsId, Cache.DefaultVernWs, "Did not get the default vernacular when there are no others.");
+			Assert.IsTrue(retStr == null || retStr.Text == null);
 
 			CoreWritingSystemDefinition mluWs;
 			WritingSystemServices.FindOrCreateWritingSystem(Cache, null, "mlu", false, false, out mluWs);


### PR DESCRIPTION
LT-20662: Fix crash adding a new custom field to Analyze

Fix an ArgumentOutOfRangeException when adding a new custom
field on the Analyze tab.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/liblcm/205)
<!-- Reviewable:end -->
