### PR TITLE
Add TargetFramework property back into .csproj files

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,20 +1,21 @@
 <Project>
   <PropertyGroup>
+    <!-- Projects that produce Nuget packages still need TargetFrameworks for Appveyor Auto Packaging -->
     <TargetFrameworks>net461</TargetFrameworks>
     <Configurations>Debug;Release</Configurations>
     <Description>The liblcm library is the core FieldWorks model for linguistic analyses of languages. Tools in this library provide the ability to store and interact with language and culture data, including anthropological, text corpus, and linguistics data.</Description>
     <Company>SIL International</Company>
     <Authors>SIL International</Authors>
     <Product>liblcm</Product>
-    <Copyright>Copyright © 2010-2021 SIL International</Copyright>
+    <Copyright>Copyright © 2010-2022 SIL International</Copyright>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageProjectUrl>https://github.com/sillsdev/liblcm</PackageProjectUrl>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
-    <OutputPath>../../artifacts/$(Configuration)</OutputPath>
-    <PackageOutputPath>../../artifacts</PackageOutputPath>
+    <OutputPath>$(MSBuildThisFileDirectory)/artifacts/$(Configuration)</OutputPath>
+    <PackageOutputPath>$(MSBuildThisFileDirectory)/artifacts</PackageOutputPath>
     <SignAssembly>true</SignAssembly>
     <WarningsAsErrors>NU1605;CS8002</WarningsAsErrors>
-    <AssemblyOriginatorKeyFile>../../liblcm.snk</AssemblyOriginatorKeyFile>
+    <AssemblyOriginatorKeyFile>$(MSBuildThisFileDirectory)/liblcm.snk</AssemblyOriginatorKeyFile>
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
@@ -23,6 +24,6 @@
 See full changelog at https://github.com/sillsdev/liblcm/blob/develop/CHANGELOG.md]]>
     </AppendToReleaseNotesProperty>
     <UseFullSemVerForNuGet>false</UseFullSemVerForNuGet>
-    <ChangelogFile>../../CHANGELOG.md</ChangelogFile>
+    <ChangelogFile>$(MSBuildThisFileDirectory)/CHANGELOG.md</ChangelogFile>
   </PropertyGroup>
 </Project>

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,18 +5,21 @@ branches:
 image: Visual Studio 2019
 configuration: Release
 init:
-  - cmd: >-
+  - cmd: |
       set GITVERSION_BUILD_NUMBER=%APPVEYOR_BUILD_NUMBER%
-
-      if defined APPVEYOR_PULL_REQUEST_NUMBER set GitVersion_NoNormalizeEnabled=true
-
-      git config --global core.autocrlf true
+      set GitVersion_NoNormalizeEnabled=true
+      set IGNORE_NORMALISATION_GIT_HEAD_MOVE=1
+install:
+  - choco install gitversion.portable -pre -y
 nuget:
   disable_publish_on_pr: true
   disable_publish_octopus: true
 before_build:
-  - cmd: >-
-      if defined APPVEYOR_PULL_REQUEST_NUMBER git checkout -b PR-%APPVEYOR_PULL_REQUEST_NUMBER%
+  - cmd: |
+      set GitVersion_NoNormalizeEnabled=true
+      set IGNORE_NORMALISATION_GIT_HEAD_MOVE=1
+      if defined APPVEYOR_PULL_REQUEST_NUMBER (git checkout -B PR-%APPVEYOR_PULL_REQUEST_NUMBER%) else (git checkout -B %APPVEYOR_REPO_BRANCH%)
+      gitversion /l console /output buildserver /nonormalize
 build:
   publish_nuget: true
   publish_nuget_symbols: true

--- a/src/CSTools/Tools/Tools.csproj
+++ b/src/CSTools/Tools/Tools.csproj
@@ -1,11 +1,11 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
+    <TargetFrameworks>net461</TargetFrameworks>
     <RootNamespace>SIL.LCModel.Tools</RootNamespace>
     <AssemblyName>SIL.LCModel.Tools</AssemblyName>
     <Description>SIL LCModel Lexer/Parser Tools</Description>
     <OutputPath>../../../artifacts/$(Configuration)</OutputPath>
-    <IsPackable>true</IsPackable>
     <PackageOutputPath>../../../artifacts</PackageOutputPath>
     <ChangelogFile>../../../CHANGELOG.md</ChangelogFile>
     <AssemblyOriginatorKeyFile>../../../liblcm.snk</AssemblyOriginatorKeyFile>

--- a/src/SIL.LCModel.Build.Tasks/SIL.LCModel.Build.Tasks.csproj
+++ b/src/SIL.LCModel.Build.Tasks/SIL.LCModel.Build.Tasks.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <RootNamespace>SIL.LCModel.Build.Tasks</RootNamespace>
+    <TargetFrameworks>net461</TargetFrameworks>
     <Description>The liblcm library is the core FieldWorks model for linguistic analyses of languages. Tools in this library provide the ability to store and interact with language and culture data, including anthropological, text corpus, and linguistics data.
 SIL.LCModel.Build.Tasks provides msbuild tasks for generating C# classes for the FieldWorks model: IdlImp and LcmGenerate.</Description>
     <BuildOutputTargetFolder>tools/$(TargetFramework)</BuildOutputTargetFolder>

--- a/src/SIL.LCModel.Core/SIL.LCModel.Core.csproj
+++ b/src/SIL.LCModel.Core/SIL.LCModel.Core.csproj
@@ -1,10 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
+    <TargetFrameworks>net461</TargetFrameworks>
     <RootNamespace>SIL.LCModel.Core</RootNamespace>
     <Description>The liblcm library is the core FieldWorks model for linguistic analyses of languages. Tools in this library provide the ability to store and interact with language and culture data, including anthropological, text corpus, and linguistics data.
 SIL.LCModel.Core provides a base library with core functionality.</Description>
-    <IsPackable>true</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/SIL.LCModel.FixData/SIL.LCModel.FixData.csproj
+++ b/src/SIL.LCModel.FixData/SIL.LCModel.FixData.csproj
@@ -1,10 +1,10 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
+    <TargetFrameworks>net461</TargetFrameworks>
     <RootNamespace>SIL.LCModel.FixData</RootNamespace>
     <Description>The liblcm library is the core FieldWorks model for linguistic analyses of languages. Tools in this library provide the ability to store and interact with language and culture data, including anthropological, text corpus, and linguistics data.
 SIL.LCModel.FixData provides functionality to fix errors in a FieldWorks data XML file.</Description>
-    <IsPackable>true</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/SIL.LCModel.Utils/SIL.LCModel.Utils.csproj
+++ b/src/SIL.LCModel.Utils/SIL.LCModel.Utils.csproj
@@ -1,10 +1,10 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
+    <TargetFrameworks>net461</TargetFrameworks>
     <RootNamespace>SIL.LCModel.Utils</RootNamespace>
     <Description>The liblcm library is the core FieldWorks model for linguistic analyses of languages. Tools in this library provide the ability to store and interact with language and culture data, including anthropological, text corpus, and linguistics data.
 SIL.LCModel.Utils provides utility classes.</Description>
-    <IsPackable>true</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/SIL.LCModel/SIL.LCModel.csproj
+++ b/src/SIL.LCModel/SIL.LCModel.csproj
@@ -1,10 +1,11 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
+    <TargetFrameworks>net461</TargetFrameworks>
     <RootNamespace>SIL.LCModel</RootNamespace>
     <Description>The liblcm library is the core FieldWorks model for linguistic analyses of languages. Tools in this library provide the ability to store and interact with language and culture data, including anthropological, text corpus, and linguistics data.
-SIL.LCModel is the main library.</Description>
-    <IsPackable>true</IsPackable>
+	SIL.LCModel is the main library.</Description>
+    <Product>liblcm</Product>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/SIL.LCModel.Core.Tests/SIL.LCModel.Core.Tests.csproj
+++ b/tests/SIL.LCModel.Core.Tests/SIL.LCModel.Core.Tests.csproj
@@ -1,10 +1,10 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
+    <TargetFrameworks>net461</TargetFrameworks>
     <RootNamespace>SIL.LCModel.Core</RootNamespace>
     <Description>The liblcm library is the core FieldWorks model for linguistic analyses of languages. Tools in this library provide the ability to store and interact with language and culture data, including anthropological, text corpus, and linguistics data.
 This package provides unit tests for SIL.LCModel.Core.</Description>
-    <IsPackable>true</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/SIL.LCModel.Tests/SIL.LCModel.Tests.csproj
+++ b/tests/SIL.LCModel.Tests/SIL.LCModel.Tests.csproj
@@ -1,10 +1,10 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
+    <TargetFrameworks>net461</TargetFrameworks>
     <RootNamespace>SIL.LCModel</RootNamespace>
     <Description>The liblcm library is the core FieldWorks model for linguistic analyses of languages. Tools in this library provide the ability to store and interact with language and culture data, including anthropological, text corpus, and linguistics data.
 This package provides unit tests for SIL.LCModel.</Description>
-    <IsPackable>true</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/SIL.LCModel.Utils.Tests/SIL.LCModel.Utils.Tests.csproj
+++ b/tests/SIL.LCModel.Utils.Tests/SIL.LCModel.Utils.Tests.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
+    <TargetFrameworks>net461</TargetFrameworks>
     <RootNamespace>SIL.LCModel.Utils</RootNamespace>
   </PropertyGroup>
 

--- a/tests/TestHelper/TestHelper.csproj
+++ b/tests/TestHelper/TestHelper.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
+    <TargetFrameworks>net461</TargetFrameworks>
     <RootNamespace>Icu.Tests</RootNamespace>
     <Description>TestHelper</Description>
     <IsPackable>false</IsPackable>


### PR DESCRIPTION
- Required for AppVeyor Automatic Packaging
* Use $(MSBuildThisFileDirectory) in Directory.Build.props
  to locate Paths
* Also properly set version number in builds.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/liblcm/214)
<!-- Reviewable:end -->
