### PR TITLE
LT-20816: Add a Case Tailoring Model to LDML

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Fixed
 
 - [SIL.LCModel.Core] Copy `SIL.LCModel.Core.dll.config` to output directory
+- [SIL.LCModel.Core] (and others) Use the `WritingSystemDefirition.CaseAlias`, if any, in `CaseFunctions`
 
 ## [10.1.0] - 2021-10-01
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Fixed
 
 - [SIL.LCModel.Core] Copy `SIL.LCModel.Core.dll.config` to output directory
-- [SIL.LCModel.Core] (and others) Use the `WritingSystemDefirition.CaseAlias`, if any, in `CaseFunctions`
+- [SIL.LCModel] Use `CaseFunctions` (to use the `WritingSystemDefinition.CaseAlias`, if any)
+- [SIL.LCModel.Core] Use the `WritingSystemDefinition.CaseAlias`, if any, in `CaseFunctions`
+
+### Deprecated
+
+- [SIL.LCModel.Core] `new CaseFunctions(string)` in favor of the new `new CaseFunctions(CoreWritingSystemDefinition)`
 
 ## [10.1.0] - 2021-10-01
 

--- a/LCM.sln.DotSettings
+++ b/LCM.sln.DotSettings
@@ -1,12 +1,21 @@
 ﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=IO/@EntryIndexedValue">IO</s:String>
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=OS/@EntryIndexedValue">OS</s:String>
+	<s:Boolean x:Key="/Default/PatternsAndTemplates/Todo/TodoPatterns/=C6562928DAAA5C419C0A4E5109498163/@KeyIndexDefined">True</s:Boolean>
+	<s:String x:Key="/Default/PatternsAndTemplates/Todo/TodoPatterns/=C6562928DAAA5C419C0A4E5109498163/Color/@EntryValue">207, 157, 50</s:String>
+	<s:Boolean x:Key="/Default/PatternsAndTemplates/Todo/TodoPatterns/=C6562928DAAA5C419C0A4E5109498163/MatchComments/@EntryValue">True</s:Boolean>
+	<s:String x:Key="/Default/PatternsAndTemplates/Todo/TodoPatterns/=C6562928DAAA5C419C0A4E5109498163/Name/@EntryValue">Review</s:String>
+	<s:String x:Key="/Default/PatternsAndTemplates/Todo/TodoPatterns/=C6562928DAAA5C419C0A4E5109498163/Pattern/@EntryValue">(?&lt;=\W|^)(?&lt;TAG&gt;REVIEW)(\W|$)(.*)</s:String>
+	<s:String x:Key="/Default/PatternsAndTemplates/Todo/TodoPatterns/=C6562928DAAA5C419C0A4E5109498163/TodoIconStyle/@EntryValue">Normal</s:String>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=analyses/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Charis/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Duolos/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=flid/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=LGPL/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=ownerless/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=Palaso/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Subentry/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=subrecords/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=unrooted/@EntryIndexedValue">True</s:Boolean>
-	<s:Boolean x:Key="/Default/UserDictionary/Words/=wordform/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=wordform/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=WS_0027s/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>

--- a/src/SIL.LCModel.Core/Text/CaseFunctions.cs
+++ b/src/SIL.LCModel.Core/Text/CaseFunctions.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2004-2013 SIL International
+// Copyright (c) 2004-2022 SIL International
 // This software is licensed under the LGPL, version 2.1 or later
 // (http://www.gnu.org/licenses/lgpl-2.1.html)
 //
@@ -6,7 +6,9 @@
 // Responsibility: FW Team
 // ---------------------------------------------------------------------------------------------
 
+using System;
 using Icu;
+using SIL.LCModel.Core.WritingSystems;
 
 namespace SIL.LCModel.Core.Text
 {
@@ -20,24 +22,28 @@ namespace SIL.LCModel.Core.Text
 	/// </summary>
 	public class CaseFunctions
 	{
-		private readonly string m_icuLocale;
-
 		/// <summary>
 		/// Make one for the specified locale (which may be null, default, or empty, root).
+		/// NB: This constructor will bypass case aliases, which will cause problems for some languages (LT-20816)
 		/// </summary>
-		/// <param name="icuLocale"></param>
+		[Obsolete]
 		public CaseFunctions(string icuLocale)
 		{
-			m_icuLocale = icuLocale;
+			IcuLocale = icuLocale;
+		}
+
+		/// <summary>
+		/// Make one for the specified Writing System (IcuLocale will be set to the WS's Case Alias, if any)
+		/// </summary>
+		public CaseFunctions(CoreWritingSystemDefinition ws)
+		{
+			IcuLocale = ws.CaseAlias ?? ws.IcuLocale;
 		}
 
 		/// <summary>
 		/// Retrieve the locale used to create it.
 		/// </summary>
-		public string IcuLocale
-		{
-			get { return m_icuLocale; }
-		}
+		public string IcuLocale { get; }
 
 		/// <summary>
 		/// Convert string to lower case equivalent.
@@ -46,7 +52,7 @@ namespace SIL.LCModel.Core.Text
 		/// <returns></returns>
 		public string ToLower(string input)
 		{
-			return UnicodeString.ToLower(input, m_icuLocale);
+			return UnicodeString.ToLower(input, IcuLocale);
 		}
 		/// <summary>
 		/// Convert string to title case equivalent.
@@ -55,7 +61,7 @@ namespace SIL.LCModel.Core.Text
 		/// <returns></returns>
 		public string ToTitle(string input)
 		{
-			return UnicodeString.ToTitle(input, m_icuLocale);
+			return UnicodeString.ToTitle(input, IcuLocale);
 		}
 		/// <summary>
 		/// Convert string to upper case equivalent.
@@ -64,7 +70,7 @@ namespace SIL.LCModel.Core.Text
 		/// <returns></returns>
 		public string ToUpper(string input)
 		{
-			return UnicodeString.ToUpper(input, m_icuLocale);
+			return UnicodeString.ToUpper(input, IcuLocale);
 		}
 
 		/// <summary>

--- a/src/SIL.LCModel/DomainServices/AnalysisGuessServices.cs
+++ b/src/SIL.LCModel/DomainServices/AnalysisGuessServices.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2009-2013 SIL International
+// Copyright (c) 2009-2022 SIL International
 // This software is licensed under the LGPL, version 2.1 or later
 // (http://www.gnu.org/licenses/lgpl-2.1.html)
 //
@@ -652,8 +652,8 @@ namespace SIL.LCModel.DomainServices
 			if (occurrence.Analysis is IWfiWordform && occurrence.Index == 0)
 			{
 				ITsString tssWfBaseline = occurrence.BaselineText;
-				CoreWritingSystemDefinition ws = Cache.ServiceLocator.WritingSystemManager.Get(tssWfBaseline.get_WritingSystemAt(0));
-				string sLower = UnicodeString.ToLower(tssWfBaseline.Text, ws.IcuLocale);
+				var cf = new CaseFunctions(Cache.ServiceLocator.WritingSystemManager.Get(tssWfBaseline.get_WritingSystemAt(0)));
+				string sLower = cf.ToLower(tssWfBaseline.Text);
 				// don't bother looking up the lowercased wordform if the instanceOf is already in lowercase form.
 				if (sLower != tssWfBaseline.Text)
 				{

--- a/src/SIL.LCModel/DomainServices/ITextUtils.cs
+++ b/src/SIL.LCModel/DomainServices/ITextUtils.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2003-2017 SIL International
+// Copyright (c) 2003-2022 SIL International
 // This software is licensed under the LGPL, version 2.1 or later
 // (http://www.gnu.org/licenses/lgpl-2.1.html)
 
@@ -1482,12 +1482,11 @@ namespace SIL.LCModel.DomainServices
 			if (str == null)
 				return null;
 
-			string strLower = null;
-			if (!s_wordformToLower.TryGetValue(str, out strLower))
+			if (!s_wordformToLower.TryGetValue(str, out var strLower))
 			{
 				// add the lowercase form to this dictionary.
-				CoreWritingSystemDefinition ws = m_wsManager.Get(tss.get_WritingSystemAt(0));
-				strLower = UnicodeString.ToLower(str, ws.IcuLocale);
+				var cf = new CaseFunctions(m_wsManager.Get(tss.get_WritingSystemAt(0)));
+				strLower = cf.ToLower(str);
 				s_wordformToLower[str] = strLower;
 			}
 			return strLower;

--- a/src/SIL.LCModel/Infrastructure/Impl/RepositoryAdditions.cs
+++ b/src/SIL.LCModel/Infrastructure/Impl/RepositoryAdditions.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2009-2017 SIL International
+// Copyright (c) 2009-2022 SIL International
 // This software is licensed under the LGPL, version 2.1 or later
 // (http://www.gnu.org/licenses/lgpl-2.1.html)
 //
@@ -13,7 +13,6 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
 using System.Text;
-using Icu;
 using SIL.LCModel.Core.Cellar;
 using SIL.LCModel.Core.KernelInterfaces;
 using SIL.LCModel.Core.Phonology;
@@ -859,7 +858,7 @@ namespace SIL.LCModel.Infrastructure.Impl
 			{
 				int ws = TsStringUtils.GetWsAtOffset(tssForm, 0);
 				// try finding a lowercase version.
-				var cf = new CaseFunctions(m_cache.ServiceLocator.WritingSystemManager.Get(ws).IcuLocale);
+				var cf = new CaseFunctions(m_cache.ServiceLocator.WritingSystemManager.Get(ws));
 				string lcForm = cf.ToLower(tssForm.Text);
 				// we want to look up the lower case form only if the given form was not already lowercased.
 				if (lcForm != tssForm.Text)
@@ -1459,9 +1458,9 @@ namespace SIL.LCModel.Infrastructure.Impl
 				//We need to be careful when converting to lowercase therefore use CustomIcu.ToLower()
 				//get the WS of the tsString
 				int wsWf = TsStringUtils.GetWsAtOffset(tssWf, 0);
-				//use that to get the locale for the WS, which is used for
-				string wsLocale = cache.ServiceLocator.WritingSystemManager.Get(wsWf).IcuLocale;
-				string sLower = UnicodeString.ToLower(tssWf.Text, wsLocale);
+				//use that to get the locale-specific CaseFunctions for the WS
+				var caseFunctions = new CaseFunctions(cache.ServiceLocator.WritingSystemManager.Get(wsWf));
+				string sLower = caseFunctions.ToLower(tssWf.Text);
 				ITsTextProps ttp = tssWf.get_PropertiesAt(0);
 				tssWf = TsStringUtils.MakeString(sLower, ttp);
 				entries = FindEntriesForWordformWorker(cache, tssWf, wfa, ref duplicates);
@@ -1551,11 +1550,10 @@ namespace SIL.LCModel.Infrastructure.Impl
 				return null;
 
 			CoreWritingSystemDefinition wsVern = cache.ServiceLocator.WritingSystemManager.Get(tssWf.get_WritingSystemAt(0));
-			string wf = UnicodeString.ToLower(tssWf.Text, wsVern.IcuLocale);
-			ILexEntry matchingEntry = null;
+			string wf = new CaseFunctions(wsVern).ToLower(tssWf.Text);
 
 			// Check for Lexeme form.
-			matchingEntry = (
+			var matchingEntry = (
 				from e in cache.LanguageProject.LexDbOA.Entries
 				where e.LexemeFormOA != null && GetLowercaseStringFromMultiUnicodeSafely(e.LexemeFormOA.Form, wsVern) == wf
 				orderby e.HomographNumber
@@ -1617,7 +1615,7 @@ namespace SIL.LCModel.Infrastructure.Impl
 			if (formTsstring == null || formTsstring.Length == 0)
 				return string.Empty;
 
-			return UnicodeString.ToLower(formTsstring.Text, ws.IcuLocale);
+			return new CaseFunctions(ws).ToLower(formTsstring.Text);
 		}
 	}
 	#endregion

--- a/tests/SIL.LCModel.Core.Tests/Text/CaseFunctionsTest.cs
+++ b/tests/SIL.LCModel.Core.Tests/Text/CaseFunctionsTest.cs
@@ -1,9 +1,11 @@
-// Copyright (c) 2003-2017 SIL International
+// Copyright (c) 2003-2022 SIL International
 // This software is licensed under the LGPL, version 2.1 or later
 // (http://www.gnu.org/licenses/lgpl-2.1.html)
 
 using NUnit.Framework;
+using SIL.LCModel.Core.WritingSystems;
 using SIL.LCModel.Utils;
+// ReSharper disable StringLiteralTypo - spell check is case-hypersensitive
 
 namespace SIL.LCModel.Core.Text
 {
@@ -13,18 +15,48 @@ namespace SIL.LCModel.Core.Text
 	[TestFixture]
 	public class CaseFunctionsTest
 	{
-		/// <summary>
-		///
-		/// </summary>
+		/// <summary/>
+		[TestCase("en", null, ExpectedResult = "en", TestName = "Normal")]
+		[TestCase("qaa", null, ExpectedResult = "root", TestName = "Private Use")]
+		[TestCase("tkr", "az", ExpectedResult = "az", TestName = "Case Alias")]
+		public string WritingSystemCtor(string locale, string caseAlias)
+		{
+			return new CaseFunctions(new CoreWritingSystemDefinition(locale) { CaseAlias = caseAlias }).IcuLocale;
+		}
+
+		/// <summary/>
+		[TestCase("en", "Igloo", ExpectedResult = "igloo")]
+		[TestCase("tur", "I'm NOT dotted", ExpectedResult = "\u0131'm not dotted")]
+		public string ToLower_UsesIcuLocale(string locale, string input)
+		{
+			return new CaseFunctions(locale).ToLower(input);
+		}
+
+		/// <summary/>
+		[TestCase("en", "intp", ExpectedResult = "INTP")]
+		[TestCase("tur", "Dotted i", ExpectedResult = "DOTTED \u0130")]
+		public string ToUpper_UsesIcuLocale(string locale, string input)
+		{
+			return new CaseFunctions(locale).ToUpper(input);
+		}
+
+		/// <summary/>
+		[TestCase("en", "intrepID", ExpectedResult = "Intrepid")]
+		[TestCase("tur", "inDIA", ExpectedResult = "\u0130nd\u0131a")]
+		public string ToTitle_UsesIcuLocale(string locale, string input)
+		{
+			return new CaseFunctions(locale).ToTitle(input);
+		}
+
+		/// <summary/>
 		[Test]
 		public void TestToLower()
 		{
 			CaseFunctions cf = new CaseFunctions("en");
 			Assert.AreEqual("abc", cf.ToLower("ABC"));
 		}
-		/// <summary>
-		///
-		/// </summary>
+
+		/// <summary/>
 		[Test]
 		public void TestStringCase()
 		{

--- a/tests/SIL.LCModel.Core.Tests/Text/CaseFunctionsTest.cs
+++ b/tests/SIL.LCModel.Core.Tests/Text/CaseFunctionsTest.cs
@@ -29,7 +29,7 @@ namespace SIL.LCModel.Core.Text
 		[TestCase("tur", "I'm NOT dotted", ExpectedResult = "\u0131'm not dotted")]
 		public string ToLower_UsesIcuLocale(string locale, string input)
 		{
-			return new CaseFunctions(locale).ToLower(input);
+			return new CaseFunctions(new CoreWritingSystemDefinition(locale)).ToLower(input);
 		}
 
 		/// <summary/>
@@ -37,7 +37,7 @@ namespace SIL.LCModel.Core.Text
 		[TestCase("tur", "Dotted i", ExpectedResult = "DOTTED \u0130")]
 		public string ToUpper_UsesIcuLocale(string locale, string input)
 		{
-			return new CaseFunctions(locale).ToUpper(input);
+			return new CaseFunctions(new CoreWritingSystemDefinition(locale)).ToUpper(input);
 		}
 
 		/// <summary/>
@@ -45,14 +45,14 @@ namespace SIL.LCModel.Core.Text
 		[TestCase("tur", "inDIA", ExpectedResult = "\u0130nd\u0131a")]
 		public string ToTitle_UsesIcuLocale(string locale, string input)
 		{
-			return new CaseFunctions(locale).ToTitle(input);
+			return new CaseFunctions(new CoreWritingSystemDefinition(locale)).ToTitle(input);
 		}
 
 		/// <summary/>
 		[Test]
 		public void TestToLower()
 		{
-			CaseFunctions cf = new CaseFunctions("en");
+			CaseFunctions cf = new CaseFunctions(new CoreWritingSystemDefinition("en"));
 			Assert.AreEqual("abc", cf.ToLower("ABC"));
 		}
 
@@ -60,7 +60,7 @@ namespace SIL.LCModel.Core.Text
 		[Test]
 		public void TestStringCase()
 		{
-			CaseFunctions cf = new CaseFunctions("en");
+			CaseFunctions cf = new CaseFunctions(new CoreWritingSystemDefinition("en"));
 			Assert.AreEqual(StringCaseStatus.allLower, cf.StringCase("abc"));
 			Assert.AreEqual(StringCaseStatus.allLower, cf.StringCase(""));
 			Assert.AreEqual(StringCaseStatus.allLower, cf.StringCase(null));

--- a/tests/SIL.LCModel.Core.Tests/Text/CaseFunctionsTest.cs
+++ b/tests/SIL.LCModel.Core.Tests/Text/CaseFunctionsTest.cs
@@ -26,7 +26,7 @@ namespace SIL.LCModel.Core.Text
 
 		/// <summary/>
 		[TestCase("en", "Igloo", ExpectedResult = "igloo")]
-		[TestCase("tur", "I'm NOT dotted", ExpectedResult = "\u0131'm not dotted")]
+		[TestCase("tr", "I'm NOT dotted", ExpectedResult = "\u0131'm not dotted")]
 		public string ToLower_UsesIcuLocale(string locale, string input)
 		{
 			return new CaseFunctions(new CoreWritingSystemDefinition(locale)).ToLower(input);
@@ -34,7 +34,7 @@ namespace SIL.LCModel.Core.Text
 
 		/// <summary/>
 		[TestCase("en", "intp", ExpectedResult = "INTP")]
-		[TestCase("tur", "Dotted i", ExpectedResult = "DOTTED \u0130")]
+		[TestCase("tr", "Dotted i", ExpectedResult = "DOTTED \u0130")]
 		public string ToUpper_UsesIcuLocale(string locale, string input)
 		{
 			return new CaseFunctions(new CoreWritingSystemDefinition(locale)).ToUpper(input);
@@ -42,7 +42,7 @@ namespace SIL.LCModel.Core.Text
 
 		/// <summary/>
 		[TestCase("en", "intrepID", ExpectedResult = "Intrepid")]
-		[TestCase("tur", "inDIA", ExpectedResult = "\u0130nd\u0131a")]
+		[TestCase("az", "inDIA", ExpectedResult = "\u0130nd\u0131a")]
 		public string ToTitle_UsesIcuLocale(string locale, string input)
 		{
 			return new CaseFunctions(new CoreWritingSystemDefinition(locale)).ToTitle(input);


### PR DESCRIPTION
For at least one minority language, we need to tailor case mapping
to a regional language. See https://jira.sil.org/browse/LT-20816

- Convert all UnicodeString.ToCase calls to CaseFunctions.ToCase
- Always construct CaseFunctions using the CoreWritingSystemDefinition

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/liblcm/218)
<!-- Reviewable:end -->
