### PR TITLE
LT-20819: Finish, fill out Copy method

### DIFF
--- a/LCM.sln.DotSettings
+++ b/LCM.sln.DotSettings
@@ -14,6 +14,7 @@
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=LGPL/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=ownerless/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Palaso/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=Palaso_0027s/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Subentry/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=subrecords/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=unrooted/@EntryIndexedValue">True</s:Boolean>

--- a/src/SIL.LCModel.Core/WritingSystems/CoreWritingSystemDefinition.cs
+++ b/src/SIL.LCModel.Core/WritingSystems/CoreWritingSystemDefinition.cs
@@ -43,6 +43,8 @@ namespace SIL.LCModel.Core.WritingSystems
 		public CoreWritingSystemDefinition(CoreWritingSystemDefinition ws, bool cloneId = false)
 			: base(ws, cloneId)
 		{
+			m_mainCharacterSet = ws.m_mainCharacterSet == null ? null : new CharacterSetDefinition(ws.m_mainCharacterSet);
+			m_wordFormingOverrides.AddRange(ws.m_wordFormingOverrides);
 			SetupCollectionChangeListeners();
 		}
 
@@ -256,6 +258,7 @@ namespace SIL.LCModel.Core.WritingSystems
 			Language = source.Language;
 			Script = source.Script;
 			Region = source.Region;
+			LanguageTag = source.LanguageTag;
 			Variants.ReplaceAll(source.Variants);
 			Abbreviation = source.Abbreviation;
 			RightToLeftScript = source.RightToLeftScript;
@@ -270,6 +273,7 @@ namespace SIL.LCModel.Core.WritingSystems
 			LocalKeyboard = source.LocalKeyboard;
 			WindowsLcid = source.WindowsLcid;
 			DefaultRegion = source.DefaultRegion;
+			DefaultFontSize = source.DefaultFontSize;
 			KnownKeyboards.ReplaceAll(source.KnownKeyboards);
 			MatchedPairs.Clear();
 			MatchedPairs.UnionWith(source.MatchedPairs);
@@ -277,12 +281,17 @@ namespace SIL.LCModel.Core.WritingSystems
 			PunctuationPatterns.UnionWith(source.PunctuationPatterns);
 			QuotationMarks.ReplaceAll(source.QuotationMarks);
 			QuotationParagraphContinueType = source.QuotationParagraphContinueType;
+			CaseAlias = source.CaseAlias;
+			DefaultCollationType = source.DefaultCollationType;
 			Collations.ReplaceAll(source.Collations.CloneItems());
 			DefaultCollation = source.DefaultCollation == null ? null : Collations[source.Collations.IndexOf(source.DefaultCollation)];
 			CharacterSets.ReplaceAll(source.CharacterSets.CloneItems());
-			NumberingSystem = source.NumberingSystem;
+			NumberingSystem = new NumberingSystemDefinition(source.NumberingSystem);
 			LegacyMapping = source.LegacyMapping;
 			IsGraphiteEnabled = source.IsGraphiteEnabled;
+			m_mainCharacterSet = source.m_mainCharacterSet == null ? null : new CharacterSetDefinition(source.m_mainCharacterSet);
+			m_wordFormingOverrides.Clear();
+			m_wordFormingOverrides.AddRange(source.m_wordFormingOverrides);
 		}
 
 		/// <summary>
@@ -308,6 +317,23 @@ namespace SIL.LCModel.Core.WritingSystems
 		public override WritingSystemDefinition Clone()
 		{
 			return new CoreWritingSystemDefinition(this);
+		}
+
+		/// <summary>
+		/// Checks for value equality with the specified writing system.
+		/// </summary>
+		public override bool ValueEquals(WritingSystemDefinition other)
+		{
+			if (!(other is CoreWritingSystemDefinition that))
+				return false;
+			if (!base.ValueEquals(other))
+				return false;
+			if (!m_mainCharacterSet?.ValueEquals(that.m_mainCharacterSet) ?? that.m_mainCharacterSet != null)
+				return false;
+			if (!m_wordFormingOverrides.SetEquals(that.m_wordFormingOverrides))
+				return false;
+
+			return true;
 		}
 
 		/// <summary>

--- a/tests/SIL.LCModel.Core.Tests/WritingSystems/CoreWritingSystemDefinitionTests.cs
+++ b/tests/SIL.LCModel.Core.Tests/WritingSystems/CoreWritingSystemDefinitionTests.cs
@@ -1,14 +1,27 @@
-// Copyright (c) 2019 SIL International
+// Copyright (c) 2019-2022 SIL International
 // This software is licensed under the LGPL, version 2.1 or later
 // (http://www.gnu.org/licenses/lgpl-2.1.html)
 
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
 using NUnit.Framework;
+using SIL.ObjectModel;
+using SIL.TestUtilities;
+using SIL.WritingSystems;
 
 namespace SIL.LCModel.Core.WritingSystems
 {
 	[TestFixture]
-	class CoreWritingSystemDefinitionTests
+	public class CoreWritingSystemDefinitionTests : CloneableTests<CoreWritingSystemDefinition, WritingSystemDefinition>
 	{
+		[OneTimeSetUp]
+		public void OneTimeSetup()
+		{
+			FieldComparer = ValueEquatableComparer.Instance;
+		}
+
 		[TestCase("en", "English")]
 		[TestCase("en-Arab", "English \\(Arabic\\)")]
 		[TestCase("en-Latn", "English \\(Latin\\)")]
@@ -22,5 +35,91 @@ namespace SIL.LCModel.Core.WritingSystems
 			var ws = new CoreWritingSystemDefinition(langTag);
 			Assert.That(ws.DisplayLabel, Does.Match(expectedLabel));
 		}
+
+		[Test]
+		public void CopyCopiesAllNeededMembers()
+		{
+			CoreWritingSystemDefinition copyable = CreateNewCloneable();
+			MethodInfo getAllFields = null;
+			var type = GetType().BaseType;
+			while(getAllFields == null && type != null)
+			{
+				getAllFields = type.GetMethod("GetAllFields", BindingFlags.NonPublic | BindingFlags.Static);
+				type = type.BaseType;
+			}
+			Assert.That(getAllFields, Is.Not.Null, "Has the signature for GetAllFields changed?");
+			var fieldInfos = (IEnumerable<FieldInfo>) getAllFields.Invoke(this, new object[] {copyable});
+
+			foreach (var fieldInfo in fieldInfos)
+			{
+				var fieldName = fieldInfo.Name;
+				var fieldType = fieldInfo.FieldType;
+				if (fieldInfo.Name.Contains("<"))
+				{
+					var splitResult = fieldInfo.Name.Split('<', '>');
+					fieldName = splitResult[1];
+				}
+				if (ExceptionList.Contains($"|{fieldName}|"))
+				{
+					continue;
+				}
+				object defaultValue = null;
+				try
+				{
+					defaultValue = DefaultValuesForTypes.Single(dv => dv.TypeOfValueToSet == fieldType).ValueToSet;
+				}
+				catch (InvalidOperationException)
+				{
+					Assert.Fail("Unhandled field type - please update the test to handle type \"{0}\". The field that uses this type is \"{1}\".", fieldType.Name, fieldName);
+				}
+
+				fieldInfo.SetValue(copyable, defaultValue);
+
+				var theCopy = CreateNewCloneable();
+				theCopy.Copy(copyable);
+				// strings are special in .NET, so we won't worry about checking them here.
+				if (fieldType != typeof(string))
+				{
+					Assert.AreNotSame(fieldInfo.GetValue(copyable), fieldInfo.GetValue(theCopy),
+						"The field \"{0}\" refers to the same object; it was not copied.", fieldName);
+				}
+				Assert.That(fieldInfo.GetValue(theCopy), Is.EqualTo(defaultValue).Using(FieldComparer), "Field \"{0}\" not copied on Copy()", fieldName);
+			}
+		}
+
+		#region CloneableTests
+		public override CoreWritingSystemDefinition CreateNewCloneable()
+		{
+			return new CoreWritingSystemDefinition();
+		}
+
+		protected override bool Equals(CoreWritingSystemDefinition x, CoreWritingSystemDefinition y)
+		{
+			return x?.ValueEquals(y) ?? y == null;
+		}
+
+		public override string ExceptionList =>
+			// This list must be longer than ExceptionsList in Palaso's WritingSystemDefinitionCloneableTests
+			// because we don't have access to set backing fields to bypass side effects of setting
+			"|Handle|Id|IsChanged|MarkedForDeletion|PropertyChanged|PropertyChanging|Template|WritingSystemFactory" +
+			"|_characterSets|_collations|_defaultCollation|_defaultFont|_fonts|_ignoreVariantChanges|_knownKeyboards|_language" +
+			"|_languageTag|_localKeyboard|_matchedPairs|_punctuationPatterns|_quotationMarks|_region|_script|_spellCheckDictionaries|";
+
+		protected override List<ValuesToSet> DefaultValuesForTypes => new List<ValuesToSet>
+		{
+			new ValuesToSet(3.14f, 2.72f),
+			new ValuesToSet(true, false),
+			new ValuesToSet("to be", "!(to be)"),
+			new ValuesToSet(DateTime.Now, DateTime.MinValue),
+			new ValuesToSet(QuotationParagraphContinueType.All, QuotationParagraphContinueType.None),
+			new ValuesToSet(NumberingSystemDefinition.CreateCustomSystem("9876543210"), NumberingSystemDefinition.Default),
+			new ValuesToSet(
+				new BulkObservableList<VariantSubtag>(new VariantSubtag[] {"1901", "bisque"}),
+				new BulkObservableList<VariantSubtag>(new VariantSubtag[] {"foo", "bar"})),
+			new ValuesToSet(new CharacterSetDefinition("test"), new CharacterSetDefinition("type")),
+			new ValuesToSet(new HashSet<int> {1}, new HashSet<int> {2, 3})
+		};
+
+		#endregion CloneableTests
 	}
 }

--- a/tests/SIL.LCModel.Tests/DomainServices/InterlinearTestBase.cs
+++ b/tests/SIL.LCModel.Tests/DomainServices/InterlinearTestBase.cs
@@ -257,8 +257,7 @@ namespace SIL.LCModel.DomainServices
 				IAnalysis analysis = tapb.GetAnalysis(iSegment, iSegForm);
 				IWfiWordform wfInstanceOf = analysis.Wordform;
 				ITsString tssWf = wfInstanceOf.Form.get_String(ws);
-				string locale = wfInstanceOf.Services.WritingSystemManager.Get(ws).IcuLocale;
-				var cf = new CaseFunctions(locale);
+				var cf = new CaseFunctions(wfInstanceOf.Services.WritingSystemManager.Get(ws));
 				string context = String.Format("[{0}]", tssStringValue);
 				const string msg = "{0} cba mismatch in {1}.";
 				Assert.AreEqual(cf.ToLower(tssStringValue.Text), cf.ToLower(tssWf.Text),
@@ -500,8 +499,7 @@ namespace SIL.LCModel.DomainServices
 				// Add any relevant 'other case' forms.
 				int nvar;
 				int ws = tssWordformBaseline.get_Properties(0).GetIntPropValues((int)FwTextPropType.ktptWs, out nvar);
-				string locale = m_cache.ServiceLocator.WritingSystemManager.Get(ws).IcuLocale;
-				var cf = new CaseFunctions(locale);
+				var cf = new CaseFunctions(m_cache.ServiceLocator.WritingSystemManager.Get(ws));
 				switch (targetState)
 				{
 					case StringCaseStatus.allLower:


### PR DESCRIPTION
* Replace uses of the deprecated CaseFunctions(string)
* Add CaseAlias to CoreWritingSystemDefinition.Copy
* Test CoreWritingSystemDefinition.Copy
* Include CoreWSD fields in Clone and Copy

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/liblcm/220)
<!-- Reviewable:end -->
