### PR TITLE
Revert "Migration to .NET Standard (#221)"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,5 +19,6 @@ src/SIL.LCModel/Generated*.cs
 src/SIL.LCModel/DomainImpl/Generated*.cs
 src/SIL.LCModel/IOC/Generated*.cs
 src/SIL.LCModel.Core/FwKernelTlb.idl
+src/SIL.LCModel.Core/FwKernelTlb.iip
 src/SIL.LCModel.Core/FwKernelTlb.json
 icu4c.readme.txt

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,5 +1,7 @@
 <Project>
   <PropertyGroup>
+    <!-- Projects that produce Nuget packages still need TargetFrameworks for Appveyor Auto Packaging -->
+    <TargetFrameworks>net461</TargetFrameworks>
     <Configurations>Debug;Release</Configurations>
     <Description>The liblcm library is the core FieldWorks model for linguistic analyses of languages. Tools in this library provide the ability to store and interact with language and culture data, including anthropological, text corpus, and linguistics data.</Description>
     <Company>SIL International</Company>
@@ -10,7 +12,6 @@
     <PackageProjectUrl>https://github.com/sillsdev/liblcm</PackageProjectUrl>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
     <OutputPath>$(MSBuildThisFileDirectory)/artifacts/$(Configuration)</OutputPath>
-    <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
     <PackageOutputPath>$(MSBuildThisFileDirectory)/artifacts</PackageOutputPath>
     <SignAssembly>true</SignAssembly>
     <WarningsAsErrors>NU1605;CS8002</WarningsAsErrors>

--- a/LCM.sln
+++ b/LCM.sln
@@ -34,9 +34,6 @@ EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SIL.LCModel.Tests", "tests\SIL.LCModel.Tests\SIL.LCModel.Tests.csproj", "{5B119AEF-2895-44AB-BB28-6C1071A9B62B}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SIL.LCModel.Utils.Tests", "tests\SIL.LCModel.Utils.Tests\SIL.LCModel.Utils.Tests.csproj", "{F023F83B-EC39-48D4-A98C-F65E43609B20}"
-	ProjectSection(ProjectDependencies) = postProject
-		{4C7D6B65-A331-4ED7-9B53-3301E714F8E7} = {4C7D6B65-A331-4ED7-9B53-3301E714F8E7}
-	EndProjectSection
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{FCAEA2BE-E9A7-46A9-B364-28598FCEEE67}"
 	ProjectSection(SolutionItems) = preProject

--- a/before.LCM.sln.targets
+++ b/before.LCM.sln.targets
@@ -30,11 +30,12 @@
 			Condition="'$(OS)' != 'Windows_NT'" />
 	</Target>
 
-	<UsingTask TaskName="DownloadNuGet" TaskFactory="RoslynCodeTaskFactory" AssemblyFile="$(CodeTaskAssembly)" Condition="'$(OS)' == 'Windows_NT'">
+	<UsingTask TaskName="DownloadNuGet" TaskFactory="CodeTaskFactory" AssemblyFile="$(CodeTaskAssembly)" Condition="'$(OS)' == 'Windows_NT'">
 		<ParameterGroup>
 			<TargetPath ParameterType="System.String" Required="true" />
 		</ParameterGroup>
 		<Task>
+			<Reference Include="System.Core" />
 			<Using Namespace="System" />
 			<Using Namespace="System.IO" />
 			<Using Namespace="System.Net" />

--- a/src/CSTools/Tools/Tools.csproj
+++ b/src/CSTools/Tools/Tools.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>net461</TargetFrameworks>
     <RootNamespace>SIL.LCModel.Tools</RootNamespace>
     <AssemblyName>SIL.LCModel.Tools</AssemblyName>
     <Description>SIL LCModel Lexer/Parser Tools</Description>

--- a/src/CSTools/lg/lg.csproj
+++ b/src/CSTools/lg/lg.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net461</TargetFramework>
     <RootNamespace>SIL.LCModel.Tools</RootNamespace>
     <Description>Lexer Generator</Description>
     <OutputPath>../../../artifacts/$(Configuration)</OutputPath>

--- a/src/CSTools/pg/pg.csproj
+++ b/src/CSTools/pg/pg.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net461</TargetFramework>
     <RootNamespace>SIL.LCModel.Tools</RootNamespace>
     <Description>Parser Generator</Description>
     <OutputPath>../../../artifacts/$(Configuration)</OutputPath>

--- a/src/SIL.LCModel.Build.Tasks/SIL.LCModel.Build.Tasks.csproj
+++ b/src/SIL.LCModel.Build.Tasks/SIL.LCModel.Build.Tasks.csproj
@@ -2,24 +2,24 @@
 
   <PropertyGroup>
     <RootNamespace>SIL.LCModel.Build.Tasks</RootNamespace>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>net461</TargetFrameworks>
     <Description>The liblcm library is the core FieldWorks model for linguistic analyses of languages. Tools in this library provide the ability to store and interact with language and culture data, including anthropological, text corpus, and linguistics data.
 SIL.LCModel.Build.Tasks provides msbuild tasks for generating C# classes for the FieldWorks model: IdlImp and LcmGenerate.</Description>
     <BuildOutputTargetFolder>tools/$(TargetFramework)</BuildOutputTargetFolder>
 	<IsPackable>true</IsPackable>
-    <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="GitVersion.MsBuild" Version="5.6.10" PrivateAssets="All" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
     <PackageReference Include="NVelocity" Version="1.2.0" PrivateAssets="All" />
-    <PackageReference Include="SIL.IdlImporter" Version="2.0.1-beta0009" PrivateAssets="All" />
+    <PackageReference Include="SIL.IdlImporter" Version="2.0.0" PrivateAssets="All" />
     <PackageReference Include="SIL.ReleaseTasks" Version="2.5.0" PrivateAssets="All" />
   </ItemGroup>
 
   <ItemGroup>
     <Reference Include="Microsoft.Build.Framework" />
+    <Reference Include="Microsoft.Build.Utilities.v4.0" />
   </ItemGroup>
 
   <Target Name="CopyTargetsAndProps" AfterTargets="Build">
@@ -32,11 +32,11 @@ SIL.LCModel.Build.Tasks provides msbuild tasks for generating C# classes for the
     <ItemGroup>
       <None Include="$(PackageId).props" Pack="true" PackagePath="build/" />
       <None Include="$(PackageId).props" Pack="true" PackagePath="buildMultiTargeting/" />
-      <None Include="$(OutputPath)/antlr.runtime.dll" Pack="true" PackagePath="tools/$(TargetFramework)/" />
-      <None Include="$(OutputPath)/IDLImporter.dll" Pack="true" PackagePath="tools/$(TargetFramework)/" />
-      <None Include="$(OutputPath)/IDLImporter.xml" Pack="true" PackagePath="tools/$(TargetFramework)/" />
-      <None Include="$(OutputPath)/Newtonsoft.Json.dll" Pack="true" PackagePath="tools/$(TargetFramework)/" />
-      <None Include="$(OutputPath)/NVelocity.dll" Pack="true" PackagePath="tools/$(TargetFramework)/" />
+      <None Include="$(OutputPath)/net461/antlr.runtime.dll" Pack="true" PackagePath="tools/net461/" />
+      <None Include="$(OutputPath)/net461/IDLImporter.dll" Pack="true" PackagePath="tools/net461/" />
+      <None Include="$(OutputPath)/net461/IDLImporter.xml" Pack="true" PackagePath="tools/net461/" />
+      <None Include="$(OutputPath)/net461/Newtonsoft.Json.dll" Pack="true" PackagePath="tools/net461/" />
+      <None Include="$(OutputPath)/net461/NVelocity.dll" Pack="true" PackagePath="tools/net461/" />
       <None Include="$(OutputPath)/lib/**/_._" Pack="true" PackagePath="lib/" />
     </ItemGroup>
   </Target>

--- a/src/SIL.LCModel.Core/GenerateKernelCs.proj
+++ b/src/SIL.LCModel.Core/GenerateKernelCs.proj
@@ -31,7 +31,7 @@
 				UsingNamespaces="@(UsingNamespaces)"
 				IdhFiles="@(KernelIdhFiles)">
 		</IdlImp>
-		<Copy SourceFiles="$(IntermediateOutputPath)FwKernelTlb.json"
+		<Copy SourceFiles="$(IntermediateOutputPath)FwKernelTlb.iip;$(IntermediateOutputPath)FwKernelTlb.json"
 			DestinationFolder="$(OutDir)KernelInterfaces" SkipUnchangedFiles="true" OverwriteReadOnlyFiles="true" />
 	</Target>
 </Project>

--- a/src/SIL.LCModel.Core/SIL.LCModel.Core.csproj
+++ b/src/SIL.LCModel.Core/SIL.LCModel.Core.csproj
@@ -1,7 +1,7 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>net461</TargetFrameworks>
     <RootNamespace>SIL.LCModel.Core</RootNamespace>
     <Description>The liblcm library is the core FieldWorks model for linguistic analyses of languages. Tools in this library provide the ability to store and interact with language and culture data, including anthropological, text corpus, and linguistics data.
 SIL.LCModel.Core provides a base library with core functionality.</Description>
@@ -12,13 +12,15 @@ SIL.LCModel.Core provides a base library with core functionality.</Description>
     <PackageReference Include="icu.net" Version="2.8.0-beta.21" />
     <PackageReference Include="Icu4c.Win.Fw.Bin" Version="70.1.47" IncludeAssets="build" />
     <PackageReference Include="Icu4c.Win.Fw.Lib" Version="70.1.47" IncludeAssets="build" PrivateAssets="runtime" />
+    <PackageReference Include="Microsoft.DotNet.PlatformAbstractions" Version="2.0.4" />
+    <PackageReference Include="Microsoft.Extensions.DependencyModel" Version="2.0.4" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
-    <PackageReference Include="NHunspell" Version="1.2.5554.16953" GeneratePropertyPath="true" />
+    <PackageReference Include="NHunspell.Patched" Version="1.2.5554" />
+    <PackageReference Include="SIL.Core.Desktop" Version="9.0.0-*" />
     <PackageReference Include="SIL.Lexicon" Version="9.0.0-*" />
     <PackageReference Include="SIL.ReleaseTasks" Version="2.5.0" PrivateAssets="All" />
-    <PackageReference Include="SIL.WritingSystems" Version="9.0.0-*" />
-    <PackageReference Include="System.Drawing.Common" Version="6.0.2-mauipre.1.22054.8" />
     <PackageReference Include="System.Runtime.InteropServices.RuntimeInformation" Version="4.3.0" />
+    <PackageReference Include="System.ValueTuple" Version="4.5.0" />
     <PackageReference Include="vswhere" Version="2.8.4" PrivateAssets="all" />
     <ProjectReference Include="..\CSTools\Tools\Tools.csproj" />
     <ProjectReference Include="..\SIL.LCModel.Build.Tasks\SIL.LCModel.Build.Tasks.csproj" />
@@ -78,15 +80,9 @@ SIL.LCModel.Core provides a base library with core functionality.</Description>
     <None Include="App.config" Pack="true" PackagePath="contentFiles\any\any\$(AssemblyTitle).dll.config" />
   </ItemGroup>
 
-  <ItemGroup>
-    <None Include="$(PkgNHunspell)\content\Hunspellx64.dll" CopyToOutputDirectory="PreserveNewest" />
-    <None Include="$(PkgNHunspell)\content\Hunspellx86.dll" CopyToOutputDirectory="PreserveNewest" />
-  </ItemGroup>
-
   <PropertyGroup>
-    <OutDir Condition="'$(OutDir)' == ''">../../artifacts/$(Configuration)/</OutDir>
+    <OutDir Condition="'$(OutDir)' == ''">../../artifacts/$(Configuration)/net461/</OutDir>
     <IntermediateOutputPath Condition="'$(IntermediateOutputPath)' == ''">obj/x86/$(Configuration)/</IntermediateOutputPath>
-    <MsBuildCommand Condition="'$(MsBuildRuntimeType)'=='Core' And '$(MsBuildCommand)'==''">dotnet build</MsBuildCommand>
     <MsbuildCommand Condition="'$(OS)'=='Windows_NT' And '$(MsBuildCommand)'==''">"$(MSBuildBinPath)\msbuild.exe"</MsbuildCommand>
     <MsbuildCommand Condition="'$(OS)'=='Unix' And '$(MsBuildCommand)'==''">msbuild</MsbuildCommand>
   </PropertyGroup>
@@ -98,6 +94,7 @@ SIL.LCModel.Core provides a base library with core functionality.</Description>
     <KernelInputs Include="KernelInterfaces\Language.idh" />
 
     <KernelOutputs Include="KernelInterfaces\Kernel.cs" />
+    <KernelOutputs Include="$(OutDir)KernelInterfaces\FwKernelTlb.iip" />
     <KernelOutputs Include="$(OutDir)KernelInterfaces\FwKernelTlb.json" />
     <Clean Include="@(KernelOutputs)" />
   </ItemGroup>

--- a/src/SIL.LCModel.Core/SIL.LCModel.Core.props
+++ b/src/SIL.LCModel.Core/SIL.LCModel.Core.props
@@ -1,6 +1,6 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 	<PropertyGroup>
-		<SilLCModelCoreLibPath>$(MSBuildThisFileDirectory)../lib/</SilLCModelCoreLibPath>
+		<SilLCModelCoreLibPath>$(MSBuildThisFileDirectory)../lib/net461/</SilLCModelCoreLibPath>
 		<SilLcModelCoreIcuDataFilesFolder>$(MSBuildThisFileDirectory)../contentFiles/IcuData</SilLcModelCoreIcuDataFilesFolder>
 	</PropertyGroup>
 	<ItemGroup>

--- a/src/SIL.LCModel.Core/Text/ColorUtil.cs
+++ b/src/SIL.LCModel.Core/Text/ColorUtil.cs
@@ -124,7 +124,7 @@ namespace SIL.LCModel.Core.Text
 		public static Color ConvertBGRtoColor(uint bgrColor)
 		{
 			if (bgrColor == 0xC0000000)
-				return Color.Transparent;
+				return Color.FromKnownColor(KnownColor.Transparent);
 			return ColorTranslator.FromWin32((int)bgrColor);
 		}
 

--- a/src/SIL.LCModel.FixData/SIL.LCModel.FixData.csproj
+++ b/src/SIL.LCModel.FixData/SIL.LCModel.FixData.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>net461</TargetFrameworks>
     <RootNamespace>SIL.LCModel.FixData</RootNamespace>
     <Description>The liblcm library is the core FieldWorks model for linguistic analyses of languages. Tools in this library provide the ability to store and interact with language and culture data, including anthropological, text corpus, and linguistics data.
 SIL.LCModel.FixData provides functionality to fix errors in a FieldWorks data XML file.</Description>

--- a/src/SIL.LCModel.Utils/SIL.LCModel.Utils.csproj
+++ b/src/SIL.LCModel.Utils/SIL.LCModel.Utils.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>net461</TargetFrameworks>
     <RootNamespace>SIL.LCModel.Utils</RootNamespace>
     <Description>The liblcm library is the core FieldWorks model for linguistic analyses of languages. Tools in this library provide the ability to store and interact with language and culture data, including anthropological, text corpus, and linguistics data.
 SIL.LCModel.Utils provides utility classes.</Description>
@@ -10,14 +10,12 @@ SIL.LCModel.Utils provides utility classes.</Description>
   <ItemGroup>
     <PackageReference Include="GitVersion.MsBuild" Version="5.6.10" PrivateAssets="All" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
-    <PackageReference Include="Mono.Posix.NETStandard" Version="1.0.0" />
     <PackageReference Include="SIL.Core" Version="9.0.0-*" />
     <PackageReference Include="SIL.ReleaseTasks" Version="2.5.0" PrivateAssets="All" />
+    <PackageReference Include="Mono.Posix" Version="5.4.0.201" PrivateAssets="All" Condition="'$(OS)' == 'Windows_NT'" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
-    <PackageReference Include="System.Configuration.ConfigurationManager" Version="5.0.0" />
-    <PackageReference Include="System.Diagnostics.PerformanceCounter" Version="6.0.0" />
-    <PackageReference Include="System.Management" Version="6.0.0" />
     <Reference Include="Mono.Posix" Condition="'$(OS)' != 'Windows_NT'" />
+    <Reference Include="System.Configuration" />
     <Reference Include="System.Management" />
   </ItemGroup>
 

--- a/src/SIL.LCModel/DomainServices/LcmStyleSheet.cs
+++ b/src/SIL.LCModel/DomainServices/LcmStyleSheet.cs
@@ -290,10 +290,6 @@ namespace SIL.LCModel.DomainServices
 			{
 				var style = m_cache.ServiceLocator.GetInstance<IStStyleRepository>().GetObject(hvo);
 				var styleInfo = new BaseStyleInfo(style);
-				if (m_StyleInfos.Contains(styleInfo))
-				{
-					throw new DuplicateItemException($"Duplicate style found: {styleInfo.Name}");
-				}
 				m_StyleInfos.Add(styleInfo);
 			}
 

--- a/src/SIL.LCModel/DomainServices/WritingSystemServices.cs
+++ b/src/SIL.LCModel/DomainServices/WritingSystemServices.cs
@@ -94,9 +94,8 @@ namespace SIL.LCModel.DomainServices
 			get
 			{
 				var tpb = TsStringUtils.MakePropsBldr();
-				var darkColor = Color.FromArgb(64,64,64);
 				tpb.SetIntPropValues((int)FwTextPropType.ktptForeColor, (int)FwTextPropVar.ktpvDefault,
-					(int)ColorUtil.ConvertColorToBGR(darkColor));
+					(int)ColorUtil.ConvertColorToBGR(Color.FromKnownColor(KnownColor.ControlDarkDark)));
 				//				// This is the formula (red + (blue * 256 + green) * 256) for a FW RGB color,
 				//				// applied to the standard FW color "light blue". This is the default defn of the
 				//				// "Language Code" character style in DN. We could just use this style, except

--- a/src/SIL.LCModel/SIL.LCModel.csproj
+++ b/src/SIL.LCModel/SIL.LCModel.csproj
@@ -1,7 +1,7 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>net461</TargetFrameworks>
     <RootNamespace>SIL.LCModel</RootNamespace>
     <Description>The liblcm library is the core FieldWorks model for linguistic analyses of languages. Tools in this library provide the ability to store and interact with language and culture data, including anthropological, text corpus, and linguistics data.
 	SIL.LCModel is the main library.</Description>
@@ -17,21 +17,22 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="CommonServiceLocator" Version="1.4.0" />
+    <PackageReference Include="CommonServiceLocator" Version="1.0.0" />
     <PackageReference Include="GitVersion.MsBuild" Version="5.6.10" PrivateAssets="All" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
-    <PackageReference Include="protobuf-net" Version="2.4.6" />
+    <PackageReference Include="protobuf-net" Version="2.0.0.668" />
     <PackageReference Include="SharpZipLib" Version="0.86.0" />
-    <PackageReference Include="SIL.Lexicon" Version="9.0.0-beta0104" />
     <PackageReference Include="SIL.ReleaseTasks" Version="2.5.0" PrivateAssets="All" />
-    <PackageReference Include="SIL.WritingSystems" Version="9.0.0-beta0104" />
     <PackageReference Include="structuremap.patched" Version="2.5.4" />
-    <PackageReference Include="System.ServiceProcess.ServiceController" Version="6.0.2-mauipre.1.22054.8" />
   </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\SIL.LCModel.Core\SIL.LCModel.Core.csproj" />
-    <ProjectReference Include="..\SIL.LCModel.Utils\SIL.LCModel.Utils.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Reference Include="System.ServiceProcess" />
+    <Reference Include="System.Web" />
   </ItemGroup>
 
   <ItemGroup>
@@ -84,8 +85,7 @@
   </ItemGroup>
 
   <PropertyGroup>
-    <OutDir Condition="'$(OutDir)' == ''">../../artifacts/$(Configuration)/</OutDir>
-    <MsBuildCommand Condition="'$(MsBuildRuntimeType)'=='Core' And '$(MsBuildCommand)'==''">dotnet build</MsBuildCommand>
+    <OutDir Condition="'$(OutDir)' == ''">../../artifacts/$(Configuration)/net461/</OutDir>
     <MsbuildCommand Condition="'$(OS)'=='Windows_NT' And '$(MsBuildCommand)'==''">"$(MSBuildBinPath)\msbuild.exe"</MsbuildCommand>
     <MsbuildCommand Condition="'$(OS)'=='Unix' And '$(MsBuildCommand)'==''">msbuild</MsbuildCommand>
   </PropertyGroup>

--- a/tests/SIL.LCModel.Core.Tests/Text/CustomIcuFallbackTests.cs
+++ b/tests/SIL.LCModel.Core.Tests/Text/CustomIcuFallbackTests.cs
@@ -121,6 +121,7 @@ namespace SIL.LCModel.Core.Text
 				"SIL.LCModel.Utils",
 				"icu.net",
 				"SIL.Core",
+				"SIL.Core.Desktop",
 				"Microsoft.Extensions.DependencyModel"
 			})
 			{

--- a/tests/SIL.LCModel.FixData.Tests/SIL.LCModel.FixData.Tests.csproj
+++ b/tests/SIL.LCModel.FixData.Tests/SIL.LCModel.FixData.Tests.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net461</TargetFramework>
     <RootNamespace>SIL.LCModel.FixData</RootNamespace>
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/tests/SIL.LCModel.Tests/TestDirectoryFinder.cs
+++ b/tests/SIL.LCModel.Tests/TestDirectoryFinder.cs
@@ -25,6 +25,7 @@ namespace SIL.LCModel
 			{
 				// we'll assume the executing assembly is <root>/artifacts/Debug/SIL.LCModel.Tests.dll,
 				string dir = CodeDirectory;
+				dir = Path.GetDirectoryName(dir);		// strip the parent directory name (net461)
 				dir = Path.GetDirectoryName(dir);       // strip the parent directory name (Debug)
 				dir = Path.GetDirectoryName(dir);       // strip the parent directory again (artifacts)
 				return dir;


### PR DESCRIPTION
The FieldWorks build is broken with this commit: rolling back
temporarily to release 9.1.12, will re-apply and work out a fix
in our next sprint.

This reverts commit d22427c0f0ce9165ebb9237b53e9d28c68be9bbc.