### PR TITLE
LT-21034: Don’t throw when the Owner is not a ILexSense

### DIFF
--- a/src/SIL.LCModel/DomainImpl/OverridesLing_Lex.cs
+++ b/src/SIL.LCModel/DomainImpl/OverridesLing_Lex.cs
@@ -532,7 +532,8 @@ namespace SIL.LCModel.DomainImpl
 		[VirtualProperty(CellarPropertyType.ReferenceAtomic, "LexSense")]
 		public ILexSense OwningSense
 		{
-			get { return (ILexSense)Owner; }
+			// Return null if the owner is not a ILexSense (LT-21034).
+			get { return Owner as ILexSense; }
 		}
 
 		/// <summary>


### PR DESCRIPTION
Return null instead of throwing when the Owner is not a ILexSense.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/liblcm/234)
<!-- Reviewable:end -->
