### PR TITLE
LT-21034: Don’t throw when the Owner is not a ILexSense

### DIFF
--- a/src/SIL.LCModel/DomainImpl/OverridesLing_Lex.cs
+++ b/src/SIL.LCModel/DomainImpl/OverridesLing_Lex.cs
@@ -532,7 +532,16 @@ namespace SIL.LCModel.DomainImpl
 		[VirtualProperty(CellarPropertyType.ReferenceAtomic, "LexSense")]
 		public ILexSense OwningSense
 		{
-			get { return (ILexSense)Owner; }
+			// If the Owner is not a ILexSense then try to return Owner.Owner (LT-21034).
+			get
+			{
+				if (Owner is ILexSense)
+					return Owner as ILexSense;
+				else if (Owner.Owner is ILexSense)
+					return Owner.Owner as ILexSense;
+				else
+					return null;
+			}
 		}
 
 		/// <summary>


### PR DESCRIPTION
If the Owner is not a ILexSense then try to return Owner.Owner, else null.