### PR TITLE
Add IsPackable flag to our test support packages

### DIFF
--- a/tests/SIL.LCModel.Core.Tests/SIL.LCModel.Core.Tests.csproj
+++ b/tests/SIL.LCModel.Core.Tests/SIL.LCModel.Core.Tests.csproj
@@ -5,6 +5,7 @@
     <RootNamespace>SIL.LCModel.Core</RootNamespace>
     <Description>The liblcm library is the core FieldWorks model for linguistic analyses of languages. Tools in this library provide the ability to store and interact with language and culture data, including anthropological, text corpus, and linguistics data.
 This package provides unit tests for SIL.LCModel.Core.</Description>
+    <IsPackable>true</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/SIL.LCModel.Tests/SIL.LCModel.Tests.csproj
+++ b/tests/SIL.LCModel.Tests/SIL.LCModel.Tests.csproj
@@ -5,6 +5,7 @@
     <RootNamespace>SIL.LCModel</RootNamespace>
     <Description>The liblcm library is the core FieldWorks model for linguistic analyses of languages. Tools in this library provide the ability to store and interact with language and culture data, including anthropological, text corpus, and linguistics data.
 This package provides unit tests for SIL.LCModel.</Description>
+    <IsPackable>true</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/SIL.LCModel.Utils.Tests/SIL.LCModel.Utils.Tests.csproj
+++ b/tests/SIL.LCModel.Utils.Tests/SIL.LCModel.Utils.Tests.csproj
@@ -5,6 +5,7 @@
     <RootNamespace>SIL.LCModel.Utils</RootNamespace>
     <Description>The liblcm library is the core FieldWorks model for linguistic analyses of languages. Tools in this library provide the ability to store and interact with language and culture data, including anthropological, text corpus, and linguistics data.
 This package provides unit tests for SIL.LCModel.Utils and test utility classes</Description>
+    <IsPackable>true</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
- "dotnet pack" excludes test projects by default so
  we need to add IsPackaboe for our test projects whic
  also provide test utilities for FieldWorks (or other)
  consumers

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/liblcm/241)
<!-- Reviewable:end -->
