### PR TITLE
Clarify that a date string is user-facing (LT-20698)

### DIFF
--- a/src/SIL.LCModel/DomainImpl/OverridesNotebk.cs
+++ b/src/SIL.LCModel/DomainImpl/OverridesNotebk.cs
@@ -1,9 +1,10 @@
-﻿// Copyright (c) 2015 SIL International
+﻿// Copyright (c) 2015-2022 SIL International
 // This software is licensed under the LGPL, version 2.1 or later
 // (http://www.gnu.org/licenses/lgpl-2.1.html)
 
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using SIL.LCModel.Application.ApplicationServices;
 using SIL.LCModel.Core.Cellar;
@@ -155,7 +156,7 @@ namespace SIL.LCModel.DomainImpl
 				tisb.Append(" - ");
 				tisb.AppendTsString(Title);
 				tisb.Append(" - ");
-				tisb.Append(DateModified.ToString("d"));
+				tisb.Append(DateModified.ToString("d", CultureInfo.CurrentUICulture));
 				return tisb.GetString();
 			}
 		}


### PR DESCRIPTION
as opposed to serialised. (Serialised dates should use ISO 8601 unless another format is specifically required.)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/liblcm/247)
<!-- Reviewable:end -->
