### PR TITLE
LT-21078: Expose the string "<Not Sure>" externally.

### DIFF
--- a/src/SIL.LCModel/LCModelStrings.cs
+++ b/src/SIL.LCModel/LCModelStrings.cs
@@ -6,11 +6,11 @@ using System;
 
 namespace SIL.LCModel
 {
-	public class StringsUtil
+	public class LCModelStrings
 	{
 		/// ------------------------------------------------------------------------------------
 		/// <summary>
-		/// Expose the "<Not Sure>" string to external modules.
+		/// <inheritdoc cref="Strings.ksNotSure"/> Expose the string to external modules.
 		/// </summary>
 		/// ------------------------------------------------------------------------------------
 		public static string NotSure => Strings.ksNotSure;

--- a/src/SIL.LCModel/StringsUtil.cs
+++ b/src/SIL.LCModel/StringsUtil.cs
@@ -1,0 +1,18 @@
+// Copyright (c) 2022 SIL International
+// This software is licensed under the LGPL, version 2.1 or later
+// (http://www.gnu.org/licenses/lgpl-2.1.html)
+
+using System;
+
+namespace SIL.LCModel
+{
+	public class StringsUtil
+	{
+		/// ------------------------------------------------------------------------------------
+		/// <summary>
+		/// Expose the "<Not Sure>" string to external modules.
+		/// </summary>
+		/// ------------------------------------------------------------------------------------
+		public static string NotSure => Strings.ksNotSure;
+	}
+}


### PR DESCRIPTION
Expose the string "<Not Sure>" externally.

https://jira.sil.org/browse/LT-21078

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/liblcm/249)
<!-- Reviewable:end -->
