### PR TITLE
Copy Build Tasks config from a stable location

### DIFF
--- a/src/SIL.LCModel.Core/SIL.LCModel.Core.props
+++ b/src/SIL.LCModel.Core/SIL.LCModel.Core.props
@@ -5,7 +5,6 @@
 	</PropertyGroup>
 	<ItemGroup>
 		<ConfigFiles Include="$(MSBuildThisFileDirectory)../contentFiles/any/any/SIL.LCModel.Core.dll.config" />
-		<None Include="$(SilLCModelCoreLibPath)\SIL.LCModel.Core.dll.config" CopyToOutputDirectory="Always" />
 		<SilLcModelCoreKernelInterfaces Include="$(MSBuildThisFileDirectory)..\contentFiles\KernelInterfaces\*.id*" />
 		<SilLcModelCoreKernelReferences Include="$(MSBuildThisFileDirectory)..\contentFiles\KernelInterfaces\*.json" />
 	</ItemGroup>


### PR DESCRIPTION
lib/ contains no files directly; they are under net461 and netstandard2.0. All three .config files are presently identical.

Change-Id: I1776cd32bea498990bde3d9541e0ef1c29efdb8e

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/liblcm/259)
<!-- Reviewable:end -->
