### PR TITLE
Support parallel TestFixture use of InitializeVersificationTable

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -44,7 +44,7 @@ jobs:
 
     # Solve problems with CustomIcuFallbackTests: the current windows-latest image (2022) includes this file that breaks our tests.
     - name: Solve problems
-      run: Remove-Item c:\tools\php\icuuc70.dll -Force
+      run: Remove-Item c:\tools\php\icuuc*.dll -Force
       if: matrix.os == 'windows-latest'
 
     - name: Build

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -53,11 +53,11 @@ jobs:
     - name: Test on Linux
       run: |
         . environ
-        dotnet test --no-restore --no-build -p:ParallelizeAssembly=false --configuration Release
+        dotnet test --no-restore --no-build -p:ParallelizeAssembly=false --configuration Release -- RunConfiguration.FailWhenNoTestsFound=true
       if: matrix.os == 'ubuntu-latest'
 
     - name: Test on Windows
-      run: dotnet test --no-restore --no-build -p:ParallelizeAssembly=false --configuration Release
+      run: dotnet test --no-restore --no-build -p:ParallelizeAssembly=false --configuration Release -- RunConfiguration.FailWhenNoTestsFound=true
       if: matrix.os != 'ubuntu-latest'
 
     - name: Package

--- a/tests/SIL.LCModel.Core.Tests/SIL.LCModel.Core.Tests.csproj
+++ b/tests/SIL.LCModel.Core.Tests/SIL.LCModel.Core.Tests.csproj
@@ -14,7 +14,7 @@ This package provides unit tests for SIL.LCModel.Core.</Description>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
     <PackageReference Include="NUnit" Version="3.13.3" />
-    <PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.3.0" />
     <PackageReference Include="SIL.ReleaseTasks" Version="2.5.0" PrivateAssets="All" />
     <PackageReference Include="SIL.TestUtilities" Version="11.0.0-*" />
   </ItemGroup>

--- a/tests/SIL.LCModel.Core.Tests/Scripture/BCVRefTests.cs
+++ b/tests/SIL.LCModel.Core.Tests/Scripture/BCVRefTests.cs
@@ -5,7 +5,9 @@
 using System;
 using System.IO;
 using System.Reflection;
+using System.Threading;
 using NUnit.Framework;
+using SIL.Threading;
 
 namespace SIL.LCModel.Core.Scripture
 {
@@ -18,20 +20,42 @@ namespace SIL.LCModel.Core.Scripture
 	[TestFixture]
 	public class BCVRefTests
 	{
-		/// ------------------------------------------------------------------------------------
 		/// <summary>
-		/// Initializes the VersificationTable class for tests.
+		/// Initialize some testing files and variables, to prepare VersificationTable for test runs. Should only be done once.
 		/// </summary>
-		/// ------------------------------------------------------------------------------------
+		/// <remarks>
+		/// We assert that if these files exist they are the same as the expected data. Parallel test execution can cause
+		/// this method to be called simultaneously by different test fixtures. No teardown of these files is done.
+		/// </remarks>
 		public static void InitializeVersificationTable()
 		{
-			string vrsPath = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
-			File.WriteAllBytes(Path.Combine(vrsPath,
-				VersificationTable.GetFileNameForVersification(ScrVers.English)), Properties.TestResources.eng);
-			File.WriteAllBytes(Path.Combine(vrsPath,
-				VersificationTable.GetFileNameForVersification(ScrVers.Septuagint)), Properties.TestResources.lxx);
-			File.WriteAllBytes(Path.Combine(vrsPath,
-				VersificationTable.GetFileNameForVersification(ScrVers.Original)), Properties.TestResources.org);
+			var vrsPath = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
+			var englishFile = Path.Combine(vrsPath, VersificationTable.GetFileNameForVersification(ScrVers.English));
+			var septuagintFile =
+				Path.Combine(vrsPath, VersificationTable.GetFileNameForVersification(ScrVers.Septuagint));
+			var originalFile = Path.Combine(vrsPath, VersificationTable.GetFileNameForVersification(ScrVers.Original));
+			// Avoid race conditions between parallel tests which need the versification initialized
+			using (var mutex = new GlobalMutex("VersificationTableSetupMutex"))
+			{
+				mutex.InitializeAndLock();
+				if (!File.Exists(englishFile)) // check only the English file existence for simplicity
+				{
+					File.WriteAllBytes(englishFile, Properties.TestResources.eng);
+					File.WriteAllBytes(septuagintFile, Properties.TestResources.lxx);
+					File.WriteAllBytes(originalFile, Properties.TestResources.org);
+				}
+				else
+				{
+					// This setup code assumes that we aren't modifying the files on disk after initialization
+					Assert.That(File.ReadAllBytes(englishFile), Is.EqualTo(Properties.TestResources.eng),
+						"Error setting up VersificationTable data for Scripture Reference tests.");
+					Assert.That(File.ReadAllBytes(septuagintFile), Is.EqualTo(Properties.TestResources.lxx),
+						"Error setting up VersificationTable data for Scripture Reference tests.");
+					Assert.That(File.ReadAllBytes(originalFile), Is.EqualTo(Properties.TestResources.org),
+						"Error setting up VersificationTable data for Scripture Reference tests.");
+				}
+				mutex.Unlink();
+			}
 			VersificationTable.Initialize(vrsPath);
 		}
 

--- a/tests/SIL.LCModel.FixData.Tests/SIL.LCModel.FixData.Tests.csproj
+++ b/tests/SIL.LCModel.FixData.Tests/SIL.LCModel.FixData.Tests.csproj
@@ -11,7 +11,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
     <PackageReference Include="NUnit" Version="3.13.3" />
-    <PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.3.0" />
     <PackageReference Include="SIL.ReleaseTasks" Version="2.5.0" PrivateAssets="All" />
   </ItemGroup>
 

--- a/tests/SIL.LCModel.Tests/SIL.LCModel.Tests.csproj
+++ b/tests/SIL.LCModel.Tests/SIL.LCModel.Tests.csproj
@@ -13,7 +13,7 @@ This package provides unit tests for SIL.LCModel.</Description>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
     <PackageReference Include="NUnit" Version="3.13.3" />
-    <PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.3.0" />
     <PackageReference Include="RhinoMocks" Version="3.6.1" />
     <PackageReference Include="SIL.ReleaseTasks" Version="2.5.0" PrivateAssets="All" />
   </ItemGroup>

--- a/tests/SIL.LCModel.Utils.Tests/SIL.LCModel.Utils.Tests.csproj
+++ b/tests/SIL.LCModel.Utils.Tests/SIL.LCModel.Utils.Tests.csproj
@@ -14,7 +14,7 @@ This package provides unit tests for SIL.LCModel.Utils and test utility classes<
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
     <PackageReference Include="Mono.Unix" Version="7.1.0-final.1.21458.1" />
     <PackageReference Include="NUnit" Version="3.13.3" />
-    <PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.3.0" />
     <PackageReference Include="SIL.ReleaseTasks" Version="2.5.0" PrivateAssets="All" />
   </ItemGroup>
 


### PR DESCRIPTION
* Race conditions for test fixtures that extended SrcInMemoryLcmTestBase were likely caused by concurrent calls to InitializeVersificationTable

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/liblcm/271)
<!-- Reviewable:end -->
