### PR TITLE
use fallback for MemoryMappedFile.CreateOrOpen when not running on windows

### DIFF
--- a/src/SIL.LCModel/Infrastructure/Impl/SharedXMLBackendProvider.cs
+++ b/src/SIL.LCModel/Infrastructure/Impl/SharedXMLBackendProvider.cs
@@ -263,7 +263,7 @@ namespace SIL.LCModel.Infrastructure.Impl
 
 		private MemoryMappedFile CreateOrOpen(string name, long capacity, bool createdNew)
 		{
-			if (Platform.IsMono)
+			if (Platform.IsUnix)
 			{
 				name = Path.Combine(m_commitLogDir, name);
 				// delete old file that could be left after a crash


### PR DESCRIPTION
previous pr #270 was merged into master instead of develop as it should have been.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/liblcm/272)
<!-- Reviewable:end -->
