### PR TITLE
Add minimal logging of UnitOfWork activity

### DIFF
--- a/src/SIL.LCModel/FileTransactionLogger.cs
+++ b/src/SIL.LCModel/FileTransactionLogger.cs
@@ -1,0 +1,48 @@
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.Text;
+
+namespace SIL.LCModel
+{
+   internal class FileTransactionLogger : ITransactionLogger, IDisposable
+   {
+	   private object m_lock = new object();
+	   private FileStream m_stream;
+	   
+	   internal FileTransactionLogger(string filePath)
+	   {
+		   m_stream = File.Open(filePath, FileMode.Append, FileAccess.Write, FileShare.Read);
+	   }
+
+	   ~FileTransactionLogger()
+	   {
+		   Dispose(false);
+	   }
+
+	   public void AddBreadCrumb(string description)
+	   {
+		   lock (m_lock)
+		   {
+			   m_stream.WriteAsync(Encoding.UTF8.GetBytes((description + Environment.NewLine).ToCharArray()), 0,
+				   description.Length + 1);
+		   }
+	   }
+
+	   protected virtual void Dispose(bool disposing)
+		{
+			Debug.WriteLineIf(!disposing, "****** Missing Dispose() call for " + GetType() + ". *******");
+			lock (m_stream)
+			{
+				m_stream?.Flush();
+				m_stream?.Dispose();
+			}
+		}
+
+		public void Dispose()
+	   {
+		   Dispose(true);
+		   GC.SuppressFinalize(this);
+		}
+   }
+}

--- a/src/SIL.LCModel/IOC/LcmServiceLocatorFactory.cs
+++ b/src/SIL.LCModel/IOC/LcmServiceLocatorFactory.cs
@@ -5,6 +5,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.IO;
 using System.Runtime.InteropServices;
 using Microsoft.Practices.ServiceLocation;
 using SIL.LCModel.Application;
@@ -16,6 +17,7 @@ using SIL.LCModel.DomainServices;
 using SIL.LCModel.DomainServices.DataMigration;
 using SIL.LCModel.Infrastructure;
 using SIL.LCModel.Infrastructure.Impl;
+using SIL.Reporting;
 using StructureMap;
 using StructureMap.Pipeline;
 
@@ -56,6 +58,13 @@ namespace SIL.LCModel.IOC
 		/// ------------------------------------------------------------------------------------
 		public IServiceLocator CreateServiceLocator()
 		{
+			ITransactionLogger logger = null;
+
+			var logPath = Environment.GetEnvironmentVariable("LCM_TransactionLogPath");
+			if (!string.IsNullOrEmpty(logPath))
+			{
+				logger = new FileTransactionLogger(Path.Combine(logPath, $"lcm_transaction.{DateTime.Now.Ticks}.log"));
+			}
 			// NOTE: When creating an object through IServiceLocator.GetInstance the caller has
 			// to call Dispose() on the newly created object, unless it's a singleton
 			// (registered with LifecycleIs(new SingletonLifecycle())) in which case
@@ -108,12 +117,6 @@ namespace SIL.LCModel.IOC
 				.For<IdentityMap>()
 				.LifecycleIs(new SingletonLifecycle())
 				.Use<IdentityMap>();
-			// No. This makes a second instance of IdentityMap,
-			// which is probably not desirable.
-			//registry
-			//	.For<ICmObjectIdFactory>()
-			//	.LifecycleIs(new SingletonLifecycle())
-			//	.Use<IdentityMap>();
 			// Register IdentityMap's other interface.
 			registry
 				.For<ICmObjectIdFactory>()
@@ -184,7 +187,7 @@ namespace SIL.LCModel.IOC
 			registry
 				.For<IUndoStackManager>()
 				.Use(c => (IUndoStackManager)c.GetInstance<IUnitOfWorkService>());
-
+			registry.For<ITransactionLogger>().Use(() => logger);
 			// Add generated factories.
 			AddFactories(registry);
 

--- a/src/SIL.LCModel/ITransactionLogger.cs
+++ b/src/SIL.LCModel/ITransactionLogger.cs
@@ -1,0 +1,7 @@
+namespace SIL.LCModel
+{
+   internal interface ITransactionLogger
+   {
+	   void AddBreadCrumb(string description);
+   }
+}


### PR DESCRIPTION
* Add logger to IOC container when LCM_TransactionLogPath environment variable is defined.
* Use logging to add breadcrumbs to trace UOW calls.
* This is a first step to try and track down some intermittent failures in FieldWorks unit tests.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/liblcm/277)
<!-- Reviewable:end -->
