### PR TITLE
Stabilise build and test execution in vscode

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,6 @@
+{
+	"csharp.unitTestDebuggingOptions": {
+		// It would be preferable to "fix" the test projects to target an executable .net core framework (https://stackoverflow.com/a/48885500/2301416)
+		"type": "clr" // https://github.com/OmniSharp/omnisharp-vscode/wiki/Desktop-.NET-Framework#settingsjson-example
+	}
+}

--- a/src/SIL.LCModel.Core/SIL.LCModel.Core.csproj
+++ b/src/SIL.LCModel.Core/SIL.LCModel.Core.csproj
@@ -112,7 +112,7 @@ SIL.LCModel.Core provides a base library with core functionality.</Description>
     <Error Condition="'$(OutDir)' == ''" Text="OutDir is not defined." />
     <!-- Call the IdlImp task from SIL.LCModel.Build.Tasks in a separate msbuild process,
          so it doesn't lock the SIL.LCModel.Build.Tasks.dll in VS. -->
-    <Exec Command="$(MsbuildCommand) $(MSBuildThisFileDirectory)GenerateKernelCs.proj /p:OutDir=$(OutDir) /p:IntermediateOutputPath=$(IntermediateOutputPath) /p:Platform=$(Platform) /p:VSInstallDir=&quot;$(VSInstallDir)&quot;" />
+    <Exec Command="$(MsbuildCommand) $(MSBuildThisFileDirectory)GenerateKernelCs.proj /p:OutDir=$(OutDir) /p:IntermediateOutputPath=$(IntermediateOutputPath) /p:Platform=&quot;$(Platform)&quot; /p:VSInstallDir=&quot;$(VSInstallDir)&quot;" />
   <ItemGroup>
       <Compile Remove="KernelInterfaces\Kernel.cs" />
       <Compile Include="KernelInterfaces\Kernel.cs" />


### PR DESCRIPTION
1) Configured VS Code not to run tests as .NET core code.

The issue here is that all the test projects target framework 4.61 and standard 2.0. VS-Code uses the core-clr by default so it prefers standard 2.0. But that's not an executable platform (i.e. in a way it's invalid for a test project. See [this SO answer](https://stackoverflow.com/a/48885500/2301416)).
As commented at the code change, it would probably be preferable to change .net standard 2.0 to an executable framework (like .net7), but that change has a domino affect accross the build process and also breaks some tests. So, I don't feel comfortable dealing with that right now.

2) Added quotes around platform, because 'Any CPU' is 2 words

Seems odd that it didn't cause trouble until now.

With these 2 changes, I can now run and debug unit tests in VS Code using the provided inline "Run Test" and "Debug Test" buttons.

Perhaps the readme should be updated as well, because I can basically do everything with `dotnet run`, `dotnet build`, `dotnet test` etc. I.e. I don't need Visual Studio, `build.cmd`, any `vsvars*.bat` files or `nunit-agent.exe`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/liblcm/279)
<!-- Reviewable:end -->
