### PR TITLE
Fix NullReferenceError in SharedXMLBackendProvider under .Net Core on Linux

### DIFF
--- a/src/SIL.LCModel/Infrastructure/Impl/SharedXMLBackendProvider.cs
+++ b/src/SIL.LCModel/Infrastructure/Impl/SharedXMLBackendProvider.cs
@@ -44,7 +44,7 @@ namespace SIL.LCModel.Infrastructure.Impl
 		{
 			m_peerProcesses = new Dictionary<int, Process>();
 			m_peerID = Guid.NewGuid();
-			if (Platform.IsMono)
+			if (Platform.IsUnix)
 			{
 				// /dev/shm is not guaranteed to be available on all systems, so fall back to temp
 				m_commitLogDir = Directory.Exists("/dev/shm") ? "/dev/shm" : Path.GetTempPath();


### PR DESCRIPTION
PR #272 changed `Platform.IsMono` to `IsUnix` in the `CreateOrOpen` method of SharedXMLBackendProvider, but the `Platform.IsMono` check in the constructor was missed. This fixes that omission, and will also fix https://github.com/sillsdev/LfMerge/issues/323 (which was caused by the mismatch: when liblcm is running under .Net Core on Linux, as in LfMerge, the CreateOrOpen method ends up trying to use the `m_commitLogDir` property that the constructor never set).