### PR TITLE
LT-18415: Add a space between Grammatical Info

### DIFF
--- a/src/SIL.LCModel/DomainImpl/OverridesLing_MoClasses.cs
+++ b/src/SIL.LCModel/DomainImpl/OverridesLing_MoClasses.cs
@@ -1357,7 +1357,11 @@ namespace SIL.LCModel.DomainImpl
 			cch = bldr.Length;
 			var features = MsFeaturesOA;
 			if (features != null)
+			{
+				bldr.ReplaceTsString(cch, cch, TsStringUtils.MakeString(" ", userWs));
+				cch = bldr.Length;
 				bldr.ReplaceTsString(cch, cch, TsStringUtils.MakeString(features.ShortName, userWs));
+			}
 
 			return bldr.GetString();
 		}


### PR DESCRIPTION
Add a space after the name only if additional feature strings (MsFeaturesOA) are going to be appended.

This was a regression that was introduced with Commit f63c3405 to fix LT-17561.

The intent of this changes is to preserve the fix
for LT-17561 and fix the problem identified in LT-18415.

https://jira.sil.org/browse/LT-18415
https://jira.sil.org/browse/LT-17561

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/liblcm/281)
<!-- Reviewable:end -->
