### PR TITLE
LT-20665: Default to only publish in the Main Dictionary

### DIFF
--- a/src/SIL.LCModel/DomainImpl/OverridesCellar.cs
+++ b/src/SIL.LCModel/DomainImpl/OverridesCellar.cs
@@ -1152,7 +1152,7 @@ namespace SIL.LCModel.DomainImpl
 		protected override void AddObjectSideEffectsInternal(AddObjectEventArgs e)
 		{
 			// For a new publication, default all of the existing lexical entries to not publish in it.
-			if (this.ObjectIdName.Length >= 32 && this.ObjectIdName.GetSubstring(0, 32).Text == "Publications - CmPossibilityList")
+			if (this.OwningFlid == 5005024)
 			{
 				IEnumerable<ILexEntry> lexEntries = this.Cache.LangProject.LexDbOA.Entries;
 				if (lexEntries.Count() > 0)

--- a/src/SIL.LCModel/DomainImpl/OverridesLing_Lex.cs
+++ b/src/SIL.LCModel/DomainImpl/OverridesLing_Lex.cs
@@ -776,6 +776,27 @@ namespace SIL.LCModel.DomainImpl
 			base.SetDefaultValuesAfterInit();
 
 			RegisterVirtualsModifiedForObjectCreation(((IServiceLocatorInternal)m_cache.ServiceLocator).UnitOfWorkService);
+
+			// For a new lexical entry, default to only publish in the Main Dictionary.
+			// Note: The Main Dictionary can be renamed, but not deleted, so look for the publication that can't be deleted.
+			var mainDictIndex = this.PublishIn.ToList().FindIndex(pub => pub.CanDelete == false);
+			if (mainDictIndex != -1)
+			{
+				var flid = Cache.MetaDataCacheAccessor.GetFieldId2(LexEntryTags.kClassId, "PublishIn", true);
+
+				// Remove the publications after Main Dictionary.
+				if (mainDictIndex < PublishIn.Count() - 1)
+				{
+					m_cache.DomainDataByFlid.Replace(this.Hvo, flid, mainDictIndex+1, PublishIn.Count(), new int[0], 0);
+				}
+
+				// Remove the publications before Main Dictionary (not sure if this condition can ever occure).
+				if (mainDictIndex > 0)
+				{
+					m_cache.DomainDataByFlid.Replace(this.Hvo, flid, 0, mainDictIndex, new int[0], 0);
+				}
+
+			}
 		}
 
 		public override ICmObject ReferenceTargetOwner(int flid)

--- a/src/SIL.LCModel/DomainImpl/OverridesLing_Lex.cs
+++ b/src/SIL.LCModel/DomainImpl/OverridesLing_Lex.cs
@@ -779,9 +779,14 @@ namespace SIL.LCModel.DomainImpl
 
 			// For a new lexical entry, default to only publish in the Main Dictionary.
 			// Note: The Main Dictionary can be renamed, but not deleted, so look for the publication that can't be deleted.
-			var mainDictIndex = this.PublishIn.ToList().FindIndex(pub => pub.CanDelete == false);
-			if (mainDictIndex != -1)
+			var allCanNotDelete = this.PublishIn.ToList().FindAll(pub => pub.CanDelete == false);
+			if (allCanNotDelete.Count != 1)
 			{
+				throw new Exception("None, or more than one publication is blocked from being deleted. Expecting only the Main Dictionary to block deletion.");
+			}
+			else
+			{
+				var mainDictIndex = this.PublishIn.ToList().FindIndex(pub => pub.CanDelete == false);
 				var flid = Cache.MetaDataCacheAccessor.GetFieldId2(LexEntryTags.kClassId, "PublishIn", true);
 
 				// Remove the publications after Main Dictionary.
@@ -795,7 +800,6 @@ namespace SIL.LCModel.DomainImpl
 				{
 					m_cache.DomainDataByFlid.Replace(this.Hvo, flid, 0, mainDictIndex, new int[0], 0);
 				}
-
 			}
 		}
 

--- a/tests/SIL.LCModel.Tests/Infrastructure/Impl/LcmInvertSetTests.cs
+++ b/tests/SIL.LCModel.Tests/Infrastructure/Impl/LcmInvertSetTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2015 SIL International
+// Copyright (c) 2015 SIL International
 // This software is licensed under the LGPL, version 2.1 or later
 // (http://www.gnu.org/licenses/lgpl-2.1.html)
 
@@ -23,10 +23,13 @@ namespace SIL.LCModel.Infrastructure.Impl
 		[Test]
 		public void Replace()
 		{
+			int publishInFlid = Cache.MetaDataCacheAccessor.GetFieldId2(LexEntryTags.kClassId, "PublishIn", false);
 			var kick = MakeEntry("kick", "strike with foot");
 			var mainDict = Cache.LangProject.LexDbOA.PublicationTypesOA.PossibilitiesOS[0];
 			var pocket = MakePossibility(Cache.LangProject.LexDbOA.PublicationTypesOA, "pocket");
 			var scholar = MakePossibility(Cache.LangProject.LexDbOA.PublicationTypesOA, "scholar");
+			Assert.That(kick.PublishIn.Count(), Is.EqualTo(1));
+			Cache.DomainDataByFlid.Replace(kick.Hvo, publishInFlid, 1, 2, new int[] { pocket.Hvo, scholar.Hvo }, 2);
 			Assert.That(kick.PublishIn.Count(), Is.EqualTo(3));
 			kick.PublishIn.Replace(new ICmObject[] {pocket}, new ICmObject[0]);
 			var result = kick.PublishIn.ToArray();
@@ -39,7 +42,6 @@ namespace SIL.LCModel.Infrastructure.Impl
 			Assert.That(result[0], Is.EqualTo(pocket));
 			Assert.That(result[1], Is.EqualTo(scholar));
 
-			int publishInFlid = Cache.MetaDataCacheAccessor.GetFieldId2(LexEntryTags.kClassId, "PublishIn", false);
 			Cache.DomainDataByFlid.Replace(kick.Hvo, publishInFlid, 1, 2, new int[] {mainDict.Hvo}, 1);
 			result = kick.PublishIn.ToArray();
 			Assert.That(result.Length, Is.EqualTo(2));
@@ -57,7 +59,7 @@ namespace SIL.LCModel.Infrastructure.Impl
 		}
 
 		/// <summary>
-		/// Test the replace method. This is what we most care about.
+		/// Test the Add and Remove methods.
 		/// </summary>
 		[Test]
 		public void AddRemove()
@@ -65,8 +67,9 @@ namespace SIL.LCModel.Infrastructure.Impl
 			var kick = MakeEntry("kick", "strike with foot");
 			var mainDict = Cache.LangProject.LexDbOA.PublicationTypesOA.PossibilitiesOS[0];
 			var pocket = MakePossibility(Cache.LangProject.LexDbOA.PublicationTypesOA, "pocket");
+			kick.PublishIn.Add(pocket);
 			var result = kick.PublishIn.ToArray();
-			Assert.That(result.Length, Is.EqualTo(2)); // no action, they are all there to start!
+			Assert.That(result.Length, Is.EqualTo(2));
 			Assert.That(result[0], Is.EqualTo(mainDict));
 			Assert.That(result[1], Is.EqualTo(pocket));
 

--- a/tests/SIL.LCModel.Tests/Infrastructure/Impl/VirtualPropertyPropChangedTests.cs
+++ b/tests/SIL.LCModel.Tests/Infrastructure/Impl/VirtualPropertyPropChangedTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2015 SIL International
+// Copyright (c) 2015 SIL International
 // This software is licensed under the LGPL, version 2.1 or later
 // (http://www.gnu.org/licenses/lgpl-2.1.html)
 
@@ -1421,6 +1421,14 @@ namespace SIL.LCModel.Infrastructure.Impl
 				"Removing a publication from DoNoPublishIn should add it to PublishIn");
 
 			var pocket = MakePossibility(Cache.LangProject.LexDbOA.PublicationTypesOA, "pocket");
+			// By default lexEntries are only published in the Main Dictionary.
+			if (lexItem is ILexEntry)
+			{
+				Assert.That(reader().Count(), Is.EqualTo(1));
+				int publishInFlid = Cache.MetaDataCacheAccessor.GetFieldId2(LexEntryTags.kClassId, "PublishIn", false);
+				UndoableUnitOfWorkHelper.Do("undo clear DoNotPublish", "redo", m_actionHandler,
+					() => Cache.DomainDataByFlid.Replace(lexItem.Hvo, publishInFlid, 1, 2, new int[] { pocket.Hvo }, 1));
+			}
 			// Enhance JohnT: possibly making a new publication should generate PropChanged for
 			// all PublishIn lists in the system! But it can't be relevant to do so, because
 			// no window can be displaying the new publication. It's also probably rare enough


### PR DESCRIPTION
Change the default behavior when a new LexEntry or a new Publication is created.  We now default to only publish in the Main Dictionary.

https://jira.sil.org/browse/LT-20665

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/liblcm/282)
<!-- Reviewable:end -->
