### PR TITLE
Fix create memory mapped linux

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,0 +1,7 @@
+{
+  "sdk": {
+    "version": "6.0.0",
+    "rollForward": "latestMajor",
+    "allowPrerelease": false
+  }
+}

--- a/global.json
+++ b/global.json
@@ -1,7 +1,5 @@
 {
-  "sdk": {
-    "version": "6.0.0",
-    "rollForward": "latestMajor",
-    "allowPrerelease": false
-  }
+	"sdk": {
+		"version": "6.0.413"
+	}
 }

--- a/src/SIL.LCModel/Infrastructure/Impl/SharedXMLBackendProvider.cs
+++ b/src/SIL.LCModel/Infrastructure/Impl/SharedXMLBackendProvider.cs
@@ -44,7 +44,7 @@ namespace SIL.LCModel.Infrastructure.Impl
 		{
 			m_peerProcesses = new Dictionary<int, Process>();
 			m_peerID = Guid.NewGuid();
-			if (Platform.IsMono)
+			if (Platform.IsUnix)
 			{
 				// /dev/shm is not guaranteed to be available on all systems, so fall back to temp
 				m_commitLogDir = Directory.Exists("/dev/shm") ? "/dev/shm" : Path.GetTempPath();
@@ -157,7 +157,7 @@ namespace SIL.LCModel.Infrastructure.Impl
 								metadata.FileGeneration = metadata.CurrentGeneration;
 							}
 							RemovePeer(metadata, m_peerID);
-							delete = Platform.IsMono && metadata.Peers.Count == 0;
+							delete = Platform.IsUnix && metadata.Peers.Count == 0;
 							SaveMetadata(stream, metadata);
 						}
 					}


### PR DESCRIPTION
my previous PR #272 (related to #270) introduced a bug so that calling `CreateOrOpen` on linux would throw this error:
```
Putting project 'kjj-flex' on hold due to unhandled exception: 
System.ArgumentNullException: Value cannot be null. (Parameter 'path1')
   at System.IO.Path.Combine(String path1, String path2)
   at SIL.LCModel.Infrastructure.Impl.SharedXMLBackendProvider.CreateOrOpen(String name, Int64 capacity, Boolean createdNew)
   at SIL.LCModel.Infrastructure.Impl.SharedXMLBackendProvider.CreateSharedMemory(Boolean createdNew)
   at SIL.LCModel.Infrastructure.Impl.SharedXMLBackendProvider.StartupInternal(Int32 currentModelVersion)
   at SIL.LCModel.Infrastructure.Impl.BackendProvider.StartupInternalWithDataMigrationIfNeeded(IThreadedProgress progressDlg)
   at SIL.LCModel.Infrastructure.Impl.BackendProvider.StartupExtantLanguageProject(IProjectIdentifier projectId, Boolean fBootstrapSystem, IThreadedProgress progressDlg)
   at SIL.LCModel.LcmCache.<>c__DisplayClass12_0.<CreateCacheFromExistingData>b__0(IDataSetup dataSetup)
   at SIL.LCModel.LcmCache.CreateCacheInternal(IProjectIdentifier projectId, String userWsIcuLocale, ILcmUI ui, ILcmDirectories dirs, LcmSettings settings, Action`1 doThe, Action`1 initialize)
   at SIL.LCModel.LcmCache.CreateCacheFromExistingData(IProjectIdentifier projectId, String userWsIcuLocale, ILcmUI ui, ILcmDirectories dirs, LcmSettings settings, IThreadedProgress progressDlg)
   at LfMerge.Core.FieldWorks.FwProject.TryGetLcmCache() in /home/builder/repo/src/LfMerge.Core/FieldWorks/FwProject.cs:line 97
   at LfMerge.Core.FieldWorks.FwProject..ctor(LfMergeSettings settings, String database) in /home/builder/repo/src/LfMerge.Core/FieldWorks/FwProject.cs:line 31
   at LfMerge.Core.LanguageForgeProject.get_FieldWorksProject() in /home/builder/repo/src/LfMerge.Core/LanguageForgeProject.cs:line 93
   at LfMerge.Core.Actions.TransferMongoToLcmAction.DoRun(ILfProject project) in /home/builder/repo/src/LfMerge.Core/Actions/TransferMongoToLcmAction.cs:line 53
   at LfMerge.Core.Actions.Action.Run(ILfProject project) in /home/builder/repo/src/LfMerge.Core/Actions/Action.cs:line 110
   at LfMerge.Core.Actions.SynchronizeAction.DoRun(ILfProject project) in /home/builder/repo/src/LfMerge.Core/Actions/SynchronizeAction.cs:line 64
   at LfMerge.Core.Actions.Action.Run(ILfProject project) in /home/builder/repo/src/LfMerge.Core/Actions/Action.cs:line 110
   at LfMerge.Program.RunAction(String projectCode, ActionNames currentAction) in /home/builder/repo/src/LfMerge/Program.cs:line 124
```

part of this was fixed in #280 however it missed a cleanup step that has been included here. It also only got merged into develop and not into master so that fix isn't in a released version anyway. This corrects that by merging into master.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/liblcm/287)
<!-- Reviewable:end -->
