### PR TITLE
Add GetCaptionOrHeadword() to CmPicture

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 
+- [SIL.LCModel] Add GetCaptionOrHeadword() to CmPicture
 - [SIL.LCModel] `LCModelStrings.NotSure` to allow clients to know if a grammatical category is the placeholder
 - [SIL.LCModel.Utils] `DateTime` extension method `ToLCMTimeFormatWithMillisString()` (replaces `ReadWriteServices.FormatDateTime`)
 

--- a/src/SIL.LCModel/DomainImpl/CmPicture.cs
+++ b/src/SIL.LCModel/DomainImpl/CmPicture.cs
@@ -250,10 +250,8 @@ namespace SIL.LCModel.DomainImpl
 				bestString = Caption.GetAlternativeOrBestTss(wsId, out wsActual);
 				if (String.IsNullOrEmpty(bestString.Text))
 				{
-					// Need to call this to get the actual ws.
-					WritingSystemServices.GetMagicStringAlt(Cache, wsId, Hvo, Caption.Flid, true, out wsActual);
-
-					// Second try to get the headword.
+					// Second try to get the headword (and actual ws).
+					wsActual = WritingSystemServices.ActualWs(Cache, wsId, Hvo, 0);
 					bestString = this.OwningSense.Entry.HeadWordForWs(wsActual);
 				}
 			}

--- a/src/SIL.LCModel/DomainImpl/CmPicture.cs
+++ b/src/SIL.LCModel/DomainImpl/CmPicture.cs
@@ -211,6 +211,55 @@ namespace SIL.LCModel.DomainImpl
 			// TODO (TE-7759) Include LocationRangeType and ScaleFactor
 			return sResult;
 		}
+
+		/// <summary>
+		/// First try to get the Caption property of this CmPicture,for the given writing system name. If
+		/// there isn't one then try to get the Headword property, for the given writing system name.
+		/// </summary>
+		/// <param name="wsName">The name of the writing system, which could be "magic".</param>
+		/// <param name="wsActual">Output the id of the writing system to which the TsString belongs.</param>
+		/// <returns>The TsString of the Caption or Headword property.</returns>
+		public ITsString GetCaptionOrHeadword(string wsName, out int wsActual)
+		{
+			ITsString bestString;
+			var wsId = WritingSystemServices.GetMagicWsIdFromName(wsName);
+			// Non-magic ws.
+			if (wsId == 0)
+			{
+				wsId = Cache.WritingSystemFactory.GetWsFromStr(wsName);
+				// The config is bad or stale, so just return null
+				if (wsId == 0)
+				{
+					Debug.WriteLine("Writing system requested that is not known in the local store: {0}", wsName);
+					wsActual = 0;
+					return null;
+				}
+				// First try to get the caption.
+				bestString = Caption.get_String(wsId);
+				if (String.IsNullOrEmpty(bestString.Text))
+				{
+					// Second try to get the headword.
+					bestString = this.OwningSense.Entry.HeadWordForWs(wsId);
+				}
+				wsActual = wsId;
+			}
+			// Magic ws. (i.e. default analysis)
+			else
+			{
+				// First try to get the caption (and actual ws).
+				bestString = Caption.GetAlternativeOrBestTss(wsId, out wsActual);
+				if (String.IsNullOrEmpty(bestString.Text))
+				{
+					// Need to call this to get the actual ws.
+					WritingSystemServices.GetMagicStringAlt(Cache, wsId, Hvo, Caption.Flid, true, out wsActual);
+
+					// Second try to get the headword.
+					bestString = this.OwningSense.Entry.HeadWordForWs(wsActual);
+				}
+			}
+
+			return bestString;
+		}
 		#endregion
 
 		#region Public properties

--- a/src/SIL.LCModel/InterfaceAdditions.cs
+++ b/src/SIL.LCModel/InterfaceAdditions.cs
@@ -4614,6 +4614,15 @@ namespace SIL.LCModel
 		/// Get the sense number of the owning LexSense.
 		/// </summary>
 		ITsString SenseNumberTSS { get; }
+
+		/// <summary>
+		/// First try to get the Caption property of this CmPicture,for the given writing system name. If
+		/// there isn't one then try to get the Headword property, for the given writing system name.
+		/// </summary>
+		/// <param name="wsName">The name of the writing system, which could be "magic".</param>
+		/// <param name="wsActual">Output the id of the writing system to which the TsString belongs.</param>
+		/// <returns>The TsString of the Caption or Headword property.</returns>
+		ITsString GetCaptionOrHeadword(string wsName, out int wsActual);
 	}
 
 	/// ----------------------------------------------------------------------------------------

--- a/tests/SIL.LCModel.Tests/DomainImpl/CmPictureTests.cs
+++ b/tests/SIL.LCModel.Tests/DomainImpl/CmPictureTests.cs
@@ -653,6 +653,32 @@ namespace SIL.LCModel.DomainImpl
 			Assert.That(outStr2.Text, Contains.Substring("Headword"));
 		}
 
+		/// ------------------------------------------------------------------------------------
+		/// <summary>
+		/// Confirm that we get the correct result when a magic ws is passed in.
+		/// </summary>
+		/// ------------------------------------------------------------------------------------
+		[Test]
+		public void CaptionOrHeadword_MagicWS()
+		{
+			var magicDefaultVernacular = "vernacular";
+			int wsHandle = Cache.LangProject.DefaultVernacularWritingSystem.Handle;
+			var entry = Cache.ServiceLocator.GetInstance<ILexEntryFactory>().Create();
+			var sense = Cache.ServiceLocator.GetInstance<ILexSenseFactory>().Create();
+			entry.SensesOS.Add(sense);
+			var lexform = Cache.ServiceLocator.GetInstance<IMoStemAllomorphFactory>().Create();
+			entry.LexemeFormOA = lexform;
+			lexform.Form.VernacularDefaultWritingSystem = TsStringUtils.MakeString("Headword", wsHandle);
+			var pictureNullCaption = MakePicture(sense.Hvo, null);
+
+			// SUT
+			int wsActual = 0;
+			var outStr = pictureNullCaption.GetCaptionOrHeadword(magicDefaultVernacular, out wsActual);
+
+			Assert.That(outStr.Text, Contains.Substring("Headword"));
+			Assert.AreEqual(wsActual, wsHandle);
+		}
+
 		private ICmPicture MakePicture(int hvoOwner, ITsString captionTss)
 		{
 			var sda = Cache.DomainDataByFlid;


### PR DESCRIPTION
This change is to add a “Caption or Headword” field in Fieldworks
Dictionary Configuration. The feature is described in the first part
of this Jira ticket:
https://jira.sil.org/browse/LT-21648

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/liblcm/288)
<!-- Reviewable:end -->
