### PR TITLE
GetBestGuess(): Allow lowercase matching for all words

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 
+- [SIL.LCModel] Added a parameter to GetBestGuess() and TryGetBestGuess() to do lowercase matching regardless of the occurrence index
 - [SIL.LCModel] Add GetCaptionOrHeadword() to CmPicture
 - [SIL.LCModel] `LCModelStrings.NotSure` to allow clients to know if a grammatical category is the placeholder
 - [SIL.LCModel.Utils] `DateTime` extension method `ToLCMTimeFormatWithMillisString()` (replaces `ReadWriteServices.FormatDateTime`)

--- a/src/SIL.LCModel/DomainServices/AnalysisGuessServices.cs
+++ b/src/SIL.LCModel/DomainServices/AnalysisGuessServices.cs
@@ -645,11 +645,15 @@ namespace SIL.LCModel.DomainServices
 		/// This guess factors in the placement of an occurrence in its segment for making other
 		/// decisions like matching lowercase alternatives for sentence initial occurrences.
 		/// </summary>
-		public IAnalysis GetBestGuess(AnalysisOccurrence occurrence)
+		/// <param name="onlyIndexZeroLowercaseMatching">
+		/// True: Do lowercase matching only if the occurrence index is zero.
+		/// False: Do lowercase matching regardless of the occurrence index.
+		/// </param>
+		public IAnalysis GetBestGuess(AnalysisOccurrence occurrence, bool onlyIndexZeroLowercaseMatching = true)
 		{
 			// first see if we can make a guess based on the lowercase form of a sentence initial (non-lowercase) wordform
 			// TODO: make it look for the first word in the sentence...may not be at Index 0!
-			if (occurrence.Analysis is IWfiWordform && occurrence.Index == 0)
+			if (occurrence.Analysis is IWfiWordform && (!onlyIndexZeroLowercaseMatching || occurrence.Index == 0))
 			{
 				ITsString tssWfBaseline = occurrence.BaselineText;
 				var cf = new CaseFunctions(Cache.ServiceLocator.WritingSystemManager.Get(tssWfBaseline.get_WritingSystemAt(0)));
@@ -693,9 +697,13 @@ namespace SIL.LCModel.DomainServices
 		/// <summary>
 		///
 		/// </summary>
-		public bool TryGetBestGuess(AnalysisOccurrence occurrence, out IAnalysis bestGuess)
+		/// <param name="onlyIndexZeroLowercaseMatching">
+		/// True: Do lowercase matching only if the occurrence index is zero.
+		/// False: Do lowercase matching regardless of the occurrence index.
+		/// </param>
+		public bool TryGetBestGuess(AnalysisOccurrence occurrence, out IAnalysis bestGuess, bool onlyIndexZeroLowercaseMatching = true)
 		{
-			bestGuess = GetBestGuess(occurrence);
+			bestGuess = GetBestGuess(occurrence, onlyIndexZeroLowercaseMatching);
 			return !(bestGuess is NullWAG);
 		}
 	}


### PR DESCRIPTION
By default, GetBestGuess() only tries to do lowercase matching for occurrence index zero. This change adds a parameter to also allow lowercase matching for all occurrence indexes.

https://jira.sil.org/browse/LT-21424

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/liblcm/290)
<!-- Reviewable:end -->
