### PR TITLE
Fix undo problem when lowercase matching is used

### DIFF
--- a/src/SIL.LCModel/DomainImpl/OverridesCellar.cs
+++ b/src/SIL.LCModel/DomainImpl/OverridesCellar.cs
@@ -4412,6 +4412,14 @@ namespace SIL.LCModel.DomainImpl
 						() => wf.AddOccurenceInText(this),
 						wf,
 						Cache.MetaDataCache.GetFieldId2(WfiWordformTags.kClassId, "FullConcordanceCount", false)));
+
+					// Fix undo problem when a uppercase word uses a guess for the lowercase word  (LT-21424).
+					Cache.ActionHandlerAccessor.AddAction(new GenericPropChangeUndoAction(
+						() => wf.RemoveOccurenceInText(this),
+						() => wf.AddOccurenceInText(this),
+						wf,
+						Cache.MetaDataCache.GetFieldId2(WfiWordformTags.kClassId, "Analyses", false)));
+
 				}
 				return;
 			}


### PR DESCRIPTION
Undo was not working when an uppercase word used a guess for the lowercase word.  The undo change was getting added for the lowercase word. This pr fixes the problem by adding a undo change for the uppercase word.
https://jira.sil.org/browse/LT-21424

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/liblcm/291)
<!-- Reviewable:end -->
