### PR TITLE
Lt 21425: Caps issue with parser

### DIFF
--- a/src/SIL.LCModel/DomainServices/AnalysisGuessServices.cs
+++ b/src/SIL.LCModel/DomainServices/AnalysisGuessServices.cs
@@ -636,21 +636,22 @@ namespace SIL.LCModel.DomainServices
 			// first see if there is a relevant lowercase form of a sentence initial (non-lowercase) wordform
 			// TODO: make it look for the first word in the sentence...may not be at Index 0!
 			IWfiWordform lowercaseWf = null;
+			int ws = occurrence.BaselineWs;
 			if (occurrence.Analysis is IWfiWordform wordform)
 				{
 					if (!EntryGenerated(wordform))
-						GenerateEntryGuesses(wordform, occurrence.BaselineWs);
+						GenerateEntryGuesses(wordform, ws);
 					if (!onlyIndexZeroLowercaseMatching || occurrence.Index == 0)
 					{
-						lowercaseWf = GetLowercaseWordform(occurrence);
+						lowercaseWf = GetLowercaseWordform(occurrence, ws);
 						if (lowercaseWf != null && lowercaseWf != wordform)
 						{
 							if (!EntryGenerated(lowercaseWf))
-								GenerateEntryGuesses(lowercaseWf, occurrence.BaselineWs);
+								GenerateEntryGuesses(lowercaseWf, ws);
 						}
 					}
 			}
-			if (occurrence.BaselineWs == -1)
+			if (ws == -1)
 				return new NullWAG(); // happens with empty translation lines
 			IAnalysis bestGuess;
 			IAnalysis previous = GetPreviousWordform(occurrence.Segment, occurrence.Index);
@@ -662,10 +663,9 @@ namespace SIL.LCModel.DomainServices
 		/// <summary>
 		/// Get the lowercase word form if the occurrence is uppercase.
 		/// </summary>
-		private IWfiWordform GetLowercaseWordform(AnalysisOccurrence occurrence)
+		private IWfiWordform GetLowercaseWordform(AnalysisOccurrence occurrence, int ws)
 		{
 			ITsString tssWfBaseline = occurrence.BaselineText;
-			int ws = tssWfBaseline.get_WritingSystemAt(0);
 			var cf = new CaseFunctions(Cache.ServiceLocator.WritingSystemManager.Get(ws));
 			string sLower = cf.ToLower(tssWfBaseline.Text);
 			// don't bother looking up the lowercased wordform if the instanceOf is already in lowercase form.
@@ -681,10 +681,9 @@ namespace SIL.LCModel.DomainServices
 		// if it lowercases to the given wordform.
 		// Otherwise, return null.
 		// </summary>
-		private IWfiWordform GetOriginalCaseWordform(AnalysisOccurrence occurrence, IWfiWordform wordform)
+		private IWfiWordform GetOriginalCaseWordform(AnalysisOccurrence occurrence, IWfiWordform wordform, int ws)
 		{
 			ITsString tssWfBaseline = occurrence.BaselineText;
-			int ws = tssWfBaseline.get_WritingSystemAt(0);
 			var cf = new CaseFunctions(Cache.ServiceLocator.WritingSystemManager.Get(ws));
 			string sLower = cf.ToLower(tssWfBaseline.Text);
 			if (sLower == wordform.GetForm(ws).Text)
@@ -792,7 +791,7 @@ namespace SIL.LCModel.DomainServices
 			{
 				// Sometimes the user selects a lowercase wordform for an uppercase word.
 				// Get the original case so that we can include uppercase analyses.
-				var originalCaseWf = GetOriginalCaseWordform(occurrence, wordform);
+				var originalCaseWf = GetOriginalCaseWordform(occurrence, wordform, ws);
 				if (originalCaseWf != null)
 					wordform = originalCaseWf;
 			}
@@ -804,7 +803,7 @@ namespace SIL.LCModel.DomainServices
 			List<IWfiAnalysis> analyses = wordform.AnalysesOC.ToList();
 			if (occurrence != null && (!onlyIndexZeroLowercaseMatching || occurrence.Index == 0))
 			{
-				IWfiWordform lowercaseWf = GetLowercaseWordform(occurrence);
+				IWfiWordform lowercaseWf = GetLowercaseWordform(occurrence, ws);
 				if (lowercaseWf != null && lowercaseWf != wordform)
 				{
 					// Add lowercase analyses.

--- a/src/SIL.LCModel/DomainServices/AnalysisGuessServices.cs
+++ b/src/SIL.LCModel/DomainServices/AnalysisGuessServices.cs
@@ -704,7 +704,7 @@ namespace SIL.LCModel.DomainServices
 			// Look for an existing wordform.
 			if (Cache.ServiceLocator.GetInstance<IWfiWordformRepository>().TryGetObject(tssWord, out wf))
 				return wf;
-			// Only create a lowercase wordform if there is an entry for it in the lexicon.
+			// Only create a wordform if there is an entry for it in the lexicon.
 			var morphs = MorphServices.GetMatchingMonomorphemicMorphs(Cache, tssWord);
 			if (morphs.Count() > 0)
 			{

--- a/src/SIL.LCModel/DomainServices/AnalysisGuessServices.cs
+++ b/src/SIL.LCModel/DomainServices/AnalysisGuessServices.cs
@@ -671,9 +671,7 @@ namespace SIL.LCModel.DomainServices
 			if (sLower != tssWfBaseline.Text)
 			{
 				ITsString tssLower = TsStringUtils.MakeString(sLower, TsStringUtils.GetWsAtOffset(tssWfBaseline, 0));
-				IWfiWordform lowercaseWf;
-				if (Cache.ServiceLocator.GetInstance<IWfiWordformRepository>().TryGetObject(tssLower, out lowercaseWf))
-					return lowercaseWf;
+				return WfiWordformServices.FindOrCreateWordform(Cache, tssLower);
 			}
 			return null;
 		}

--- a/tests/SIL.LCModel.Tests/DomainServices/AnalysisGuessServicesTests.cs
+++ b/tests/SIL.LCModel.Tests/DomainServices/AnalysisGuessServicesTests.cs
@@ -145,6 +145,13 @@ namespace SIL.LCModel.DomainServices
 					", " + Words_para0[18].Form.BestVernacularAlternative.Text +
 					".", wsVern));
 				Para0.Contents = bldr2.GetString();
+				/* E. */
+				IWfiWordform E = wfFactory.Create(TsStringUtils.MakeString("E", wsVern));
+				Words_para0.Add(E);
+				var bldr3 = Para0.Contents.GetIncBldr();
+				bldr3.AppendTsString(TsStringUtils.MakeString(
+					" " + Words_para0[19].Form.BestVernacularAlternative.Text + ".", wsVern));
+				Para0.Contents = bldr3.GetString();
 				using (ParagraphParser pp = new ParagraphParser(Cache))
 				{
 					foreach (IStTxtPara para in StText.ParagraphsOS)
@@ -541,6 +548,27 @@ namespace SIL.LCModel.DomainServices
 				Assert.AreEqual(2, sorted_analyses.Count);
 				Assert.AreEqual("A", sorted_analyses[0].Analysis.Wordform.ShortName);
 				Assert.AreEqual("a", sorted_analyses[1].Analysis.Wordform.ShortName);
+			}
+		}
+
+		/// <summary>
+		/// make generated entries for upper and lower case when only upper case is in corpus.
+		/// </summary>
+		[Test]
+		public void ExpectedGuessForWord_GuessUpperAndLowerGenerated2()
+		{
+			using (var setup = new AnalysisGuessBaseSetup(Cache,
+				AnalysisGuessBaseSetup.Flags.PartsOfSpeech, AnalysisGuessBaseSetup.Flags.VariantEntryTypes))
+			{
+				// create an affix entry
+				setup.EntryFactory.Create("e", "astem", SandboxGenericMSA.Create(MsaType.kStem, setup.Pos_noun));
+				setup.EntryFactory.Create("E", "Astem", SandboxGenericMSA.Create(MsaType.kStem, setup.Pos_noun));
+				AnalysisOccurrence occurrence = new AnalysisOccurrence(setup.Para0.SegmentsOS[3], 0);
+				// GenerateEntryGuesses implicitly gets called.
+				var sorted_analyses = setup.GuessServices.GetSortedAnalysisGuesses(occurrence.Analysis.Wordform, occurrence);
+				Assert.AreEqual(2, sorted_analyses.Count);
+				Assert.AreEqual("E", sorted_analyses[0].Analysis.Wordform.ShortName);
+				Assert.AreEqual("e", sorted_analyses[1].Analysis.Wordform.ShortName);
 			}
 		}
 

--- a/tests/SIL.LCModel.Tests/DomainServices/AnalysisGuessServicesTests.cs
+++ b/tests/SIL.LCModel.Tests/DomainServices/AnalysisGuessServicesTests.cs
@@ -545,9 +545,19 @@ namespace SIL.LCModel.DomainServices
 				AnalysisOccurrence occurrence = new AnalysisOccurrence(setup.Para0.SegmentsOS[0], 0);
 				// GenerateEntryGuesses implicitly gets called.
 				var sorted_analyses = setup.GuessServices.GetSortedAnalysisGuesses(occurrence.Analysis.Wordform, occurrence);
+				// The uppercase wordform is preferred because it hasn't been lowercased.
 				Assert.AreEqual(2, sorted_analyses.Count);
 				Assert.AreEqual("A", sorted_analyses[0].Analysis.Wordform.ShortName);
 				Assert.AreEqual("a", sorted_analyses[1].Analysis.Wordform.ShortName);
+				// Test GetOriginalCaseWordform.
+				// Set the analysis to the lowercase wordform.
+				setup.Para0.SetAnalysis(0, 0, sorted_analyses[1]);
+				sorted_analyses = setup.GuessServices.GetSortedAnalysisGuesses(occurrence.Analysis.Wordform, occurrence);
+				// We should still get the uppercase wordform as a guess.
+				// The lowercase wordform is preferred because it is human-approved.
+				Assert.AreEqual(2, sorted_analyses.Count);
+				Assert.AreEqual("a", sorted_analyses[0].Analysis.Wordform.ShortName);
+				Assert.AreEqual("A", sorted_analyses[1].Analysis.Wordform.ShortName);
 			}
 		}
 


### PR DESCRIPTION
Changes the guesser to treat capitalization the same way that the parser will treat capitalization.
In particular, uppercased words are analyzed as having lowercase wordforms.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/liblcm/296)
<!-- Reviewable:end -->
