### PR TITLE
Fix crash encountered while bulk deleting entries

### DIFF
--- a/src/SIL.LCModel/DomainImpl/OverridesLing_Lex.cs
+++ b/src/SIL.LCModel/DomainImpl/OverridesLing_Lex.cs
@@ -4028,6 +4028,11 @@ namespace SIL.LCModel.DomainImpl
 		{
 			get
 			{
+				// Test the cache for null and yeild an empty list - This can happen during a bulk delete operation
+				if (m_cache == null)
+				{
+					yield break;
+				}
 				((ICmObjectRepositoryInternal) Services.ObjectRepository).EnsureCompleteIncomingRefsFrom(
 					LexEntryRefTags.kflidComponentLexemes);
 				foreach (var item in m_incomingRefs)

--- a/src/SIL.LCModel/DomainImpl/OverridesLing_Lex.cs
+++ b/src/SIL.LCModel/DomainImpl/OverridesLing_Lex.cs
@@ -4028,7 +4028,7 @@ namespace SIL.LCModel.DomainImpl
 		{
 			get
 			{
-				// Test the cache for null and yeild an empty list - This can happen during a bulk delete operation
+				// Test the cache for null and yield an empty list - This can happen during a bulk delete operation
 				if (m_cache == null)
 				{
 					yield break;


### PR DESCRIPTION
* Discovered while trying to prune entries in the project attached to https://jira.sil.org/browse/LT-18577

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/liblcm/298)
<!-- Reviewable:end -->
