### PR TITLE
Lt 21815: Eliminate empty glosses

### DIFF
--- a/src/SIL.LCModel/DomainServices/AnalysisGuessServices.cs
+++ b/src/SIL.LCModel/DomainServices/AnalysisGuessServices.cs
@@ -1032,11 +1032,16 @@ namespace SIL.LCModel.DomainServices
 							var newAnalysis = waFactory.Create(ww, wgFactory);
 							newAnalysis.CategoryRA = info.Pos;
 							// Not all entries have senses.
-							if (info.Sense != null)
+							if (info.Sense != null && info.Sense.Gloss.BestAnalysisVernacularAlternative.Length > 0)
 							{
 								// copy all the gloss alternatives from the sense into the word gloss.
 								IWfiGloss wg = newAnalysis.MeaningsOC.First();
 								wg.Form.MergeAlternatives(info.Sense.Gloss);
+							}
+							else
+							{
+								// Eliminate the dummy gloss (LT-21815).
+								newAnalysis.MeaningsOC.Clear();
 							}
 							var wmb = wmbFactory.Create();
 							newAnalysis.MorphBundlesOS.Add(wmb);

--- a/src/SIL.LCModel/DomainServices/AnalysisGuessServices.cs
+++ b/src/SIL.LCModel/DomainServices/AnalysisGuessServices.cs
@@ -1032,7 +1032,7 @@ namespace SIL.LCModel.DomainServices
 							var newAnalysis = waFactory.Create(ww, wgFactory);
 							newAnalysis.CategoryRA = info.Pos;
 							// Not all entries have senses.
-							if (info.Sense != null && info.Sense.Gloss.BestAnalysisVernacularAlternative.Length > 0)
+							if (info.Sense != null && !IsEmptyMultiUnicode(info.Sense.Gloss))
 							{
 								// copy all the gloss alternatives from the sense into the word gloss.
 								IWfiGloss wg = newAnalysis.MeaningsOC.First();
@@ -1062,6 +1062,16 @@ namespace SIL.LCModel.DomainServices
 						});
 				}
 			}
+		}
+
+		bool IsEmptyMultiUnicode(IMultiUnicode multiUnicode)
+		{
+			foreach (var ws in multiUnicode.AvailableWritingSystemIds)
+			{
+				if (multiUnicode.get_String(ws).Length > 0)
+					return false;
+			}
+			return true;
 		}
 		#endregion GenerateEntryGuesses
 	}


### PR DESCRIPTION
One of the issues with https://jira.sil.org/browse/LT-21815 is that you can get an empty word gloss if the lexical entry for a monomorphemic word has a blank gloss.  This explains why the first and second "test" behaved differently: one of them had an empty gloss, and the other had a null gloss.  This pull request eliminates empty glosses.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/liblcm/300)
<!-- Reviewable:end -->
