### PR TITLE
update CommonServiceLocator to remove Microsoft.NETCore.App dependancy

### DIFF
--- a/src/SIL.LCModel/DomainServices/BootstrapNewLanguageProject.cs
+++ b/src/SIL.LCModel/DomainServices/BootstrapNewLanguageProject.cs
@@ -4,7 +4,6 @@
 
 using System;
 using System.Diagnostics;
-using Microsoft.Practices.ServiceLocation;
 using SIL.LCModel.Core.KernelInterfaces;
 using SIL.LCModel.Core.Text;
 using SIL.LCModel.Core.WritingSystems;
@@ -23,7 +22,7 @@ namespace SIL.LCModel.DomainServices
 		/// <summary>
 		/// Create a new Language Project.
 		/// </summary>
-		internal static void BootstrapNewSystem(IServiceLocator servLoc)
+		internal static void BootstrapNewSystem(IServiceProvider servLoc)
 		{
 			using (var nonUndoableUOW = new NonUndoableUnitOfWorkHelper(servLoc.GetInstance<IActionHandler>()))
 			{

--- a/src/SIL.LCModel/DomainServices/M3ModelExportServices.cs
+++ b/src/SIL.LCModel/DomainServices/M3ModelExportServices.cs
@@ -7,7 +7,6 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Xml.Linq;
 using Icu;
-using Microsoft.Practices.ServiceLocation;
 using SIL.LCModel.Core.KernelInterfaces;
 using SIL.LCModel.Core.WritingSystems;
 
@@ -315,7 +314,7 @@ namespace SIL.LCModel.DomainServices
 		/// <summary>
 		/// Export the full lexicon when exporting both grammar and lexicon.
 		/// </summary>
-		private static XElement ExportLexiconFull(IServiceLocator servLoc, Normalizer.UNormalizationMode mode)
+		private static XElement ExportLexiconFull(IServiceProvider servLoc, Normalizer.UNormalizationMode mode)
 		{
 			return new XElement("Lexicon",
 					ExportEntries(servLoc.GetInstance<ILexEntryRepository>()),
@@ -349,7 +348,7 @@ namespace SIL.LCModel.DomainServices
 							select ExportItemAsReference(lexEntryType, "LexEntryType"))));
 		}
 
-		private static XElement ExportMsas(IServiceLocator servLoc)
+		private static XElement ExportMsas(IServiceProvider servLoc)
 		{
 			return new XElement("MorphoSyntaxAnalyses",
 				from stemMsa in servLoc.GetInstance<IMoStemMsaRepository>().AllInstances()
@@ -407,7 +406,7 @@ namespace SIL.LCModel.DomainServices
 					ExportBestAnalysis(sense.Definition, "Definition", mode)));
 		}
 
-		private static XElement ExportAllomorphs(IServiceLocator servLoc, Normalizer.UNormalizationMode mode)
+		private static XElement ExportAllomorphs(IServiceProvider servLoc, Normalizer.UNormalizationMode mode)
 		{
 			return new XElement("Allomorphs",
 				from stemAllo in servLoc.GetInstance<IMoStemAllomorphRepository>().AllInstances()

--- a/src/SIL.LCModel/ILcmServiceLocator.cs
+++ b/src/SIL.LCModel/ILcmServiceLocator.cs
@@ -3,7 +3,6 @@
 // (http://www.gnu.org/licenses/lgpl-2.1.html)
 
 using System;
-using Microsoft.Practices.ServiceLocation;
 using SIL.LCModel.Core.KernelInterfaces;
 using SIL.LCModel.Core.WritingSystems;
 using SIL.LCModel.Infrastructure;
@@ -15,7 +14,7 @@ namespace SIL.LCModel
 	/// This interface defines LCM extensions to IServiceLocator, mainly shortcuts for particular
 	/// GetService() calls.
 	/// </summary>
-	public interface ILcmServiceLocator : IServiceLocator
+	public interface ILcmServiceLocator : IServiceProvider
 	{
 		/// <summary>
 		/// Shortcut to the IActionHandler instance.
@@ -94,5 +93,22 @@ namespace SIL.LCModel
 		IdentityMap IdentityMap { get; }
 		LoadingServices LoadingServices { get; }
 		IUnitOfWorkService UnitOfWorkService { get; }
+	}
+
+	/// <summary>
+	/// Helpers to provide drop in methods that match the api of IServiceLocator, but use IServiceProvider instead.
+	/// </summary>
+	public static class IocHelpers
+	{
+		public static object GetInstance(this IServiceProvider provider, Type serviceType)
+		{
+			//todo how to handle null? Should we throw an exception?
+			return provider.GetService(serviceType);
+		}
+
+		public static TService GetInstance<TService>(this IServiceProvider provider)
+		{
+			return (TService)provider.GetService(typeof(TService));
+		}
 	}
 }

--- a/src/SIL.LCModel/ILcmServiceLocator.cs
+++ b/src/SIL.LCModel/ILcmServiceLocator.cs
@@ -3,10 +3,13 @@
 // (http://www.gnu.org/licenses/lgpl-2.1.html)
 
 using System;
+using System.Collections.Generic;
+using CommonServiceLocator;
 using SIL.LCModel.Core.KernelInterfaces;
 using SIL.LCModel.Core.WritingSystems;
 using SIL.LCModel.Infrastructure;
 using SIL.LCModel.Infrastructure.Impl;
+using SIL.LCModel.IOC;
 
 namespace SIL.LCModel
 {
@@ -109,6 +112,14 @@ namespace SIL.LCModel
 		public static TService GetInstance<TService>(this IServiceProvider provider)
 		{
 			return (TService)provider.GetService(typeof(TService));
+		}
+
+		public static IEnumerable<TService> GetAllInstances<TService>(this IServiceProvider provider)
+		{
+			//structure map might not work the same way as the standard service provider, so we need to handle it separately.
+			if (provider is IServiceLocator serviceLocator) return serviceLocator.GetAllInstances<TService>();
+			//the standard service provider handles listing all services like this, however that might not work the same in structure map if an IEnumerable is explicitly registered.
+			return (IEnumerable<TService>) provider.GetService(typeof(IEnumerable<TService>));
 		}
 	}
 }

--- a/src/SIL.LCModel/IOC/LcmServiceLocatorFactory.cs
+++ b/src/SIL.LCModel/IOC/LcmServiceLocatorFactory.cs
@@ -6,7 +6,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Runtime.InteropServices;
-using Microsoft.Practices.ServiceLocation;
+using CommonServiceLocator;
 using SIL.LCModel.Application;
 using SIL.LCModel.Application.Impl;
 using SIL.LCModel.Core.KernelInterfaces;
@@ -54,7 +54,7 @@ namespace SIL.LCModel.IOC
 		/// </summary>
 		/// <returns>An IServiceLocator instance.</returns>
 		/// ------------------------------------------------------------------------------------
-		public IServiceLocator CreateServiceLocator()
+		public IServiceProvider CreateServiceLocator()
 		{
 			// NOTE: When creating an object through IServiceLocator.GetInstance the caller has
 			// to call Dispose() on the newly created object, unless it's a singleton

--- a/src/SIL.LCModel/SIL.LCModel.csproj
+++ b/src/SIL.LCModel/SIL.LCModel.csproj
@@ -17,7 +17,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="CommonServiceLocator" Version="1.4.0" />
+    <PackageReference Include="CommonServiceLocator" Version="2.0.7" />
     <PackageReference Include="GitVersion.MsBuild" Version="5.6.10" PrivateAssets="All" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
     <PackageReference Include="protobuf-net" Version="2.4.6" />

--- a/tests/SIL.LCModel.Tests/DomainImpl/NotebookTests.cs
+++ b/tests/SIL.LCModel.Tests/DomainImpl/NotebookTests.cs
@@ -2,7 +2,7 @@
 // This software is licensed under the LGPL, version 2.1 or later
 // (http://www.gnu.org/licenses/lgpl-2.1.html)
 
-using Microsoft.Practices.ServiceLocation;
+using System;
 using NUnit.Framework;
 using SIL.LCModel.Core.Text;
 
@@ -122,7 +122,7 @@ namespace SIL.LCModel.DomainImpl
 			Assert.That(lp.Texts.Contains(text), Is.True);
 		}
 
-		private static IText MakeATextWith2Paragraphs(IServiceLocator servLoc, IRnGenericRec owner)
+		private static IText MakeATextWith2Paragraphs(IServiceProvider servLoc, IRnGenericRec owner)
 		{
 			var result = servLoc.GetInstance<ITextFactory>().Create();
 			owner.TextRA = result;


### PR DESCRIPTION
closes https://github.com/sillsdev/languageforge-lexbox/issues/964

LCM references [CommonServiceLocator](https://www.nuget.org/packages/CommonServiceLocator/1.4.0), which in turn references [Microsoft.NETCore.App](https://www.nuget.org/packages/Microsoft.NETCore.App/)

this breaks various applications when attempting to include LCM. This PR updates that dependancy.

I also did a bit of refactoring to remove references to IServiceLocator in favor of the BCL interface IServiceProvider. I then provided some extension methods so there is source compatibility with this new version. If this is too big of a change and impacts FieldWorks too much then I can remove it and just upgrade the package. However the namespace that IServiceLocator is in has changed as part of the version change, so this seemed like a good time to remove our usage of this interface as it's non standard.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/liblcm/302)
<!-- Reviewable:end -->
