### PR TITLE
Ensure tests run on ci

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -46,7 +46,7 @@ jobs:
     - name: Solve problems
       run: Remove-Item c:\tools\php\icuuc*.dll -Force
       if: matrix.os == 'windows-latest'
-      
+
     - name: Download 461 targeting pack
       uses: suisei-cn/actions-download-file@818d6b7dc8fe73f2f924b6241f2b1134ca1377d9 # 1.6.0
       id: downloadfile  # Remember to give an ID if you need the output filename
@@ -54,7 +54,7 @@ jobs:
           url: "https://download.microsoft.com/download/F/1/D/F1DEB8DB-D277-4EF9-9F48-3A65D4D8F965/NDP461-DevPack-KB3105179-ENU.exe"
           target: public/
       if: matrix.os == 'windows-latest'
-            
+
     - name: Install targeting pack
       shell: cmd
       working-directory: public
@@ -67,12 +67,18 @@ jobs:
     - name: Test on Linux
       run: |
         . environ
-        dotnet test --no-restore --no-build -p:ParallelizeAssembly=false --configuration Release -- RunConfiguration.FailWhenNoTestsFound=true
+        dotnet test --no-restore --no-build -p:ParallelizeAssembly=false --configuration Release --logger:"trx" --results-directory ./test-results
       if: matrix.os == 'ubuntu-latest'
 
     - name: Test on Windows
-      run: dotnet test -a "%UserProfile%\.nuget\packages\nunit3testadapter\4.5.0\build\net462" --no-restore --no-build -p:ParallelizeAssembly=false --configuration Release -- RunConfiguration.FailWhenNoTestsFound=true
+      run: dotnet test --no-restore --no-build -p:ParallelizeAssembly=false --configuration Release --logger:"trx" --results-directory ./test-results
       if: matrix.os != 'ubuntu-latest'
+    - name: Upload test results
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: Test results (${{ matrix.os }})
+        path: ./test-results
 
     - name: Package
       run: dotnet pack --include-symbols --no-restore --no-build -p:SymbolPackageFormat=snupkg --configuration Release
@@ -87,3 +93,19 @@ jobs:
         name: NugetPackages
         path: artifacts/*.nupkg
       if: github.event_name == 'pull_request'
+  publish-test-results:
+    runs-on: ubuntu-latest
+    needs: build
+    if: always()
+    steps:
+      - name: Download test results
+        uses: actions/download-artifact@v3
+        with:
+          path: artifacts
+      - name: Publish test results
+        uses: EnricoMi/publish-unit-test-result-action@8885e273a4343cd7b48eaa72428dea0c3067ea98 # v2.14.0
+        with:
+          check_name: LCM Tests
+          files: artifacts/**/*.trx
+          action_fail: true
+          action_fail_on_inconclusive: true

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -88,7 +88,7 @@ jobs:
       if: github.event_name == 'push' && matrix.os == 'ubuntu-latest'
 
     - name: Publish Artifacts
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: NugetPackages
         path: artifacts/*.nupkg
@@ -99,9 +99,10 @@ jobs:
     if: always()
     steps:
       - name: Download test results
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           path: artifacts
+          pattern: Test results *
       - name: Publish test results
         uses: EnricoMi/publish-unit-test-result-action@8885e273a4343cd7b48eaa72428dea0c3067ea98 # v2.14.0
         with:

--- a/src/SIL.LCModel/DomainImpl/Vectors.cs
+++ b/src/SIL.LCModel/DomainImpl/Vectors.cs
@@ -421,19 +421,13 @@ namespace SIL.LCModel.DomainImpl
 			// TODO: Check for multidimensional 'array' and throw ArgumentException, if it is.
 			lock (SyncRoot)
 			{
-				//if (arrayIndex >= array.Length || m_items.Count - arrayIndex >= array.Length)
-				// equals sign causes spurious ArgumentException when copying entire array
-				if (array.Length == 0)
-					return;
-				if (arrayIndex >= array.Length || m_items.Count - arrayIndex > array.Length)
-					throw new ArgumentException();
+				if (m_items.Count + arrayIndex > array.Length)
+					throw new ArgumentOutOfRangeException("arrayIndex");
 
-				int currentIndex = 0;
-				int currentcopiedIndex = 0;
-				foreach (var objOrId in m_items.ToArray())
+				int currentcopiedIndex = arrayIndex;
+				foreach (var cmObjectOrId in m_items)
 				{
-					if (currentIndex++ < arrayIndex) continue;
-					array.SetValue(FluffUpObjectIfNeeded(objOrId), currentcopiedIndex++);
+					array[currentcopiedIndex++] = FluffUpObjectIfNeeded(cmObjectOrId);
 				}
 			}
 		}

--- a/tests/SIL.LCModel.Core.Tests/SIL.LCModel.Core.Tests.csproj
+++ b/tests/SIL.LCModel.Core.Tests/SIL.LCModel.Core.Tests.csproj
@@ -14,7 +14,7 @@ This package provides unit tests for SIL.LCModel.Core.</Description>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
     <PackageReference Include="NUnit" Version="3.13.3" />
-    <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.3.2" />
     <PackageReference Include="SIL.ReleaseTasks" Version="2.5.0" PrivateAssets="All" />
     <PackageReference Include="SIL.TestUtilities" Version="13.0.1" />
   </ItemGroup>

--- a/tests/SIL.LCModel.Core.Tests/SIL.LCModel.Core.Tests.csproj
+++ b/tests/SIL.LCModel.Core.Tests/SIL.LCModel.Core.Tests.csproj
@@ -16,7 +16,7 @@ This package provides unit tests for SIL.LCModel.Core.</Description>
     <PackageReference Include="NUnit" Version="3.13.3" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.3.2" />
     <PackageReference Include="SIL.ReleaseTasks" Version="2.5.0" PrivateAssets="All" />
-    <PackageReference Include="SIL.TestUtilities" Version="13.0.1" />
+    <PackageReference Include="SIL.TestUtilities" Version="12.0.0-*" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/SIL.LCModel.FixData.Tests/SIL.LCModel.FixData.Tests.csproj
+++ b/tests/SIL.LCModel.FixData.Tests/SIL.LCModel.FixData.Tests.csproj
@@ -11,7 +11,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
     <PackageReference Include="NUnit" Version="3.13.3" />
-    <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.3.2" />
     <PackageReference Include="SIL.ReleaseTasks" Version="2.5.0" PrivateAssets="All" />
   </ItemGroup>
 

--- a/tests/SIL.LCModel.Tests/DomainImpl/VectorTests.cs
+++ b/tests/SIL.LCModel.Tests/DomainImpl/VectorTests.cs
@@ -396,11 +396,11 @@ namespace SIL.LCModel.DomainImpl
 
 		/// ------------------------------------------------------------------------------------
 		/// <summary>
-		/// Tests the CopyTo method.
+		/// Tests the CopyTo LcmList method.
 		/// </summary>
 		/// ------------------------------------------------------------------------------------
 		[Test]
-		public void CopyTo_OneItemInLongListTest()
+		public void CopyTo_LcmList_OneItemInLongListTest()
 		{
 			ILcmServiceLocator servLoc = Cache.ServiceLocator;
 			IScrBookFactory bookFact = servLoc.GetInstance<IScrBookFactory>();
@@ -420,11 +420,35 @@ namespace SIL.LCModel.DomainImpl
 
 		/// ------------------------------------------------------------------------------------
 		/// <summary>
+		/// Tests the CopyTo LcmSet method.
+		/// </summary>
+		/// ------------------------------------------------------------------------------------
+		[Test]
+		public void CopyTo_LcmSet_OneItemInLongListTest()
+		{
+			ILcmServiceLocator servLoc = Cache.ServiceLocator;
+			IScrDraftFactory draftFactory = servLoc.GetInstance<IScrDraftFactory>();
+
+			// Setup the source sequence using the drafts collection.
+			IScrDraft draft0 = draftFactory.Create("draft");
+
+			IScrDraft[] draftArray = new IScrDraft[5];
+			m_scr.ArchivedDraftsOC.CopyTo(draftArray, 3);
+
+			Assert.IsNull(draftArray[0]);
+			Assert.IsNull(draftArray[1]);
+			Assert.IsNull(draftArray[2]);
+			Assert.AreEqual(draft0, draftArray[3]);
+			Assert.IsNull(draftArray[4]);
+		}
+
+		/// ------------------------------------------------------------------------------------
+		/// <summary>
 		/// Tests the CopyTo method when we are copying into a one-item list.
 		/// </summary>
 		/// ------------------------------------------------------------------------------------
 		[Test]
-		public void CopyTo_OneItemInOneItemListTest()
+		public void CopyTo_LcmList_OneItemInOneItemListTest()
 		{
 			ILcmServiceLocator servLoc = Cache.ServiceLocator;
 			IScrBookFactory bookFact = servLoc.GetInstance<IScrBookFactory>();
@@ -440,16 +464,50 @@ namespace SIL.LCModel.DomainImpl
 
 		/// ------------------------------------------------------------------------------------
 		/// <summary>
+		/// Tests the CopyTo method when we are copying into a one-item set.
+		/// </summary>
+		/// ------------------------------------------------------------------------------------
+		[Test]
+		public void CopyTo_LcmSet_OneItemInOneItemListTest()
+		{
+			ILcmServiceLocator servLoc = Cache.ServiceLocator;
+			IScrDraftFactory draftFactory = servLoc.GetInstance<IScrDraftFactory>();
+
+			// Setup the source sequence using the drafts collection.
+			IScrDraft draft0 = draftFactory.Create("draft");
+
+			IScrDraft[] draftArray = new IScrDraft[1];
+			m_scr.ArchivedDraftsOC.CopyTo(draftArray, 0);
+
+			Assert.AreEqual(draft0, draftArray[0]);
+		}
+
+		/// ------------------------------------------------------------------------------------
+		/// <summary>
 		/// Tests the CopyTo method when we are copying no items into an empty list.
 		/// </summary>
 		/// ------------------------------------------------------------------------------------
 		[Test]
-		public void CopyTo_NoItemsInEmptyItemListTest()
+		public void CopyTo_LcmList_NoItemsInEmptyItemListTest()
 		{
 			ILcmServiceLocator servLoc = Cache.ServiceLocator;
 
 			IScrBook[] bookArray = new IScrBook[0];
 			m_scr.ScriptureBooksOS.CopyTo(bookArray, 0);
+			// This test makes sure that an exception is not thrown when the array is empty.
+			// This fixes creating a new List<> when giving a LcmVector as the parameter.
+		}
+
+		/// ------------------------------------------------------------------------------------
+		/// <summary>
+		/// Tests the CopyTo method when we are copying no items into an empty set.
+		/// </summary>
+		/// ------------------------------------------------------------------------------------
+		[Test]
+		public void CopyTo_LcmSet_NoItemsInEmptyItemListTest()
+		{
+			IScrDraft[] draftArray = new IScrDraft[0];
+			m_scr.ArchivedDraftsOC.CopyTo(draftArray, 0);
 			// This test makes sure that an exception is not thrown when the array is empty.
 			// This fixes creating a new List<> when giving a LcmVector as the parameter.
 		}

--- a/tests/SIL.LCModel.Tests/SIL.LCModel.Tests.csproj
+++ b/tests/SIL.LCModel.Tests/SIL.LCModel.Tests.csproj
@@ -13,7 +13,7 @@ This package provides unit tests for SIL.LCModel.</Description>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
     <PackageReference Include="NUnit" Version="3.13.3" />
-    <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.3.2" />
     <PackageReference Include="RhinoMocks" Version="3.6.1" />
     <PackageReference Include="SIL.ReleaseTasks" Version="2.5.0" PrivateAssets="All" />
   </ItemGroup>

--- a/tests/SIL.LCModel.Utils.Tests/SIL.LCModel.Utils.Tests.csproj
+++ b/tests/SIL.LCModel.Utils.Tests/SIL.LCModel.Utils.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net461</TargetFrameworks>
+    <TargetFramework>net461</TargetFramework>
     <RootNamespace>SIL.LCModel.Utils</RootNamespace>
     <Description>The liblcm library is the core FieldWorks model for linguistic analyses of languages. Tools in this library provide the ability to store and interact with language and culture data, including anthropological, text corpus, and linguistics data.
 This package provides unit tests for SIL.LCModel.Utils and test utility classes</Description>
@@ -14,7 +14,7 @@ This package provides unit tests for SIL.LCModel.Utils and test utility classes<
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
     <PackageReference Include="Mono.Unix" Version="7.1.0-final.1.21458.1" />
     <PackageReference Include="NUnit" Version="3.13.3" />
-    <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.3.2" />
     <PackageReference Include="SIL.ReleaseTasks" Version="2.5.0" PrivateAssets="All" />
   </ItemGroup>
 


### PR DESCRIPTION
currently no tests are being found and run on CI, however there's no errors. I suspect this has been happening since bc9c0da as that's when the test adapter version changed.

I've also included test reporting in CI so we will better catch when tests aren't running. It turns out the flag `RunConfiguration.FailWhenNoTestsFound=true` only works for the vstest adapter, which we're not using.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/liblcm/305)
<!-- Reviewable:end -->
