### PR TITLE
run unit tests in CI against dotnet 8

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -67,11 +67,11 @@ jobs:
     - name: Test on Linux
       run: |
         . environ
-        dotnet test --no-restore --no-build -p:ParallelizeAssembly=false --configuration Release --logger:"trx" --results-directory ./test-results
+        dotnet test --no-restore --no-build -p:ParallelizeAssembly=false --configuration Release --logger:"trx;LogFilePrefix=results" --results-directory ./test-results
       if: matrix.os == 'ubuntu-latest'
 
     - name: Test on Windows
-      run: dotnet test --no-restore --no-build -p:ParallelizeAssembly=false --configuration Release --logger:"trx" --results-directory ./test-results
+      run: dotnet test --no-restore --no-build -p:ParallelizeAssembly=false --configuration Release --logger:"trx;LogFilePrefix=results" --results-directory ./test-results
       if: matrix.os != 'ubuntu-latest'
     - name: Upload test results
       if: always()

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -28,9 +28,9 @@ jobs:
 
     # Install the .NET Core workload
     - name: Install .NET Core
-      uses: actions/setup-dotnet@v2
+      uses: actions/setup-dotnet@v4
       with:
-        dotnet-version: 6.0.x
+        dotnet-version: 8.0.x
 
     - name: Install mono-devel package
       run: sudo apt-get install mono-devel

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -94,7 +94,7 @@ jobs:
     - name: Publish Artifacts
       uses: actions/upload-artifact@v4
       with:
-        name: NugetPackages
+        name: NugetPackages (${{ matrix.os }})
         path: artifacts/*.nupkg
       if: github.event_name == 'pull_request'
   publish-test-results:

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -11,7 +11,8 @@
     <PackageProjectUrl>https://github.com/sillsdev/liblcm</PackageProjectUrl>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
     <Platform>Any CPU</Platform>
-    <OutputPath>$(MSBuildThisFileDirectory)/artifacts/$(Configuration)/$(TargetFramework)</OutputPath>
+	<Configuration Condition="'$(Configuration)' == ''">Debug</Configuration>
+    <OutputPath>$(MSBuildThisFileDirectory)artifacts/$(Configuration)/$(TargetFramework)</OutputPath>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
     <PackageOutputPath>$(MSBuildThisFileDirectory)/artifacts</PackageOutputPath>
     <SignAssembly>true</SignAssembly>

--- a/src/SIL.LCModel.Core/SIL.LCModel.Core.csproj
+++ b/src/SIL.LCModel.Core/SIL.LCModel.Core.csproj
@@ -9,16 +9,16 @@ SIL.LCModel.Core provides a base library with core functionality.</Description>
 
   <ItemGroup>
     <PackageReference Include="GitVersion.MsBuild" Version="5.6.10" PrivateAssets="All" />
-    <PackageReference Include="icu.net" Version="3.0.0-beta.296" />
+    <PackageReference Include="icu.net" Version="3.0.0-*" />
     <PackageReference Include="Icu4c.Win.Fw.Bin" Version="70.1.152" IncludeAssets="build" />
     <PackageReference Include="Icu4c.Win.Fw.Lib" Version="70.1.152" IncludeAssets="build" PrivateAssets="runtime" />
     <PackageReference Include="Microsoft.DotNet.PlatformAbstractions" Version="2.0.4" />
     <PackageReference Include="Microsoft.Extensions.DependencyModel" Version="2.0.4" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
     <PackageReference Include="NHunspell" Version="1.2.5554.16953" GeneratePropertyPath="true" />
-    <PackageReference Include="SIL.Lexicon" Version="14.2.0-beta0021" />
+    <PackageReference Include="SIL.Lexicon" Version="14.2.0-*" />
     <PackageReference Include="SIL.ReleaseTasks" Version="2.5.0" PrivateAssets="All" />
-    <PackageReference Include="SIL.WritingSystems" Version="14.2.0-beta0021" />
+    <PackageReference Include="SIL.WritingSystems" Version="14.2.0-*" />
     <PackageReference Include="System.Drawing.Common" Version="6.0.0" />
     <PackageReference Include="System.Runtime.InteropServices.RuntimeInformation" Version="4.3.0" />
     <PackageReference Include="vswhere" Version="2.8.4" PrivateAssets="all" />

--- a/src/SIL.LCModel.Core/SIL.LCModel.Core.csproj
+++ b/src/SIL.LCModel.Core/SIL.LCModel.Core.csproj
@@ -9,16 +9,16 @@ SIL.LCModel.Core provides a base library with core functionality.</Description>
 
   <ItemGroup>
     <PackageReference Include="GitVersion.MsBuild" Version="5.6.10" PrivateAssets="All" />
-    <PackageReference Include="icu.net" Version="2.*-*" />
+    <PackageReference Include="icu.net" Version="3.0.0-beta.296" />
     <PackageReference Include="Icu4c.Win.Fw.Bin" Version="70.1.152" IncludeAssets="build" />
     <PackageReference Include="Icu4c.Win.Fw.Lib" Version="70.1.152" IncludeAssets="build" PrivateAssets="runtime" />
     <PackageReference Include="Microsoft.DotNet.PlatformAbstractions" Version="2.0.4" />
     <PackageReference Include="Microsoft.Extensions.DependencyModel" Version="2.0.4" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
     <PackageReference Include="NHunspell" Version="1.2.5554.16953" GeneratePropertyPath="true" />
-    <PackageReference Include="SIL.Lexicon" Version="12.0.0-*" />
+    <PackageReference Include="SIL.Lexicon" Version="14.2.0-beta0021" />
     <PackageReference Include="SIL.ReleaseTasks" Version="2.5.0" PrivateAssets="All" />
-    <PackageReference Include="SIL.WritingSystems" Version="12.0.0-*" />
+    <PackageReference Include="SIL.WritingSystems" Version="14.2.0-beta0021" />
     <PackageReference Include="System.Drawing.Common" Version="6.0.0" />
     <PackageReference Include="System.Runtime.InteropServices.RuntimeInformation" Version="4.3.0" />
     <PackageReference Include="vswhere" Version="2.8.4" PrivateAssets="all" />

--- a/src/SIL.LCModel.Core/SIL.LCModel.Core.csproj
+++ b/src/SIL.LCModel.Core/SIL.LCModel.Core.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net461;net8.0</TargetFrameworks>
     <RootNamespace>SIL.LCModel.Core</RootNamespace>
     <Description>The liblcm library is the core FieldWorks model for linguistic analyses of languages. Tools in this library provide the ability to store and interact with language and culture data, including anthropological, text corpus, and linguistics data.
 SIL.LCModel.Core provides a base library with core functionality.</Description>
@@ -163,12 +163,12 @@ SIL.LCModel.Core provides a base library with core functionality.</Description>
   <Target Name="BeforeCoreClean" BeforeTargets="CoreClean">
     <!-- Prevent the deletion of IDLImporter.xml. This seems like a bug in msbuild - it shouldn't
     delete files it didn't copy, at least not in the middle of a rebuild -->
-    <Copy SourceFiles="$(OutputPath)/IDLImporter.xml" DestinationFiles="$(OutputPath)/../IDLImporter.xml" Condition="Exists('$(OutputPath)/IDLImporter.xml')" />
+    <Copy SourceFiles="$(OutputPath)IDLImporter.xml" DestinationFiles="$(OutputPath)../IDLImporter.xml" Condition="Exists('$(OutputPath)IDLImporter.xml')" />
   </Target>
 
   <Target Name="AfterCoreClean" AfterTargets="CoreClean">
     <!-- Restore IDLImporter.xml. -->
-    <Copy SourceFiles="$(OutputPath)/../IDLImporter.xml" DestinationFiles="$(OutputPath)/IDLImporter.xml" />
+    <Copy SourceFiles="$(OutputPath)../IDLImporter.xml" DestinationFiles="$(OutputPath)IDLImporter.xml" Condition="Exists('$(OutputPath)../IDLImporter.xml')" />
   </Target>
 
   <Target Name="CollectRuntimeOutputs" BeforeTargets="_GetPackageFiles">

--- a/src/SIL.LCModel.Utils/FileUtils.cs
+++ b/src/SIL.LCModel.Utils/FileUtils.cs
@@ -494,6 +494,7 @@ namespace SIL.LCModel.Utils
 				var invalidFileNameChars = Path.GetInvalidFileNameChars();
 				if (name.IndexOfAny(invalidFileNameChars) >= 0)
 					return false;
+				if (name == filename) return true;
 				var directoryPath = filename.Substring(0, filename.Length - name.Length);
 				if (directoryPath.IndexOfAny(Path.GetInvalidPathChars()) >= 0)
 					return false;

--- a/src/SIL.LCModel.Utils/FileUtils.cs
+++ b/src/SIL.LCModel.Utils/FileUtils.cs
@@ -473,16 +473,8 @@ namespace SIL.LCModel.Utils
 		/// ------------------------------------------------------------------------------------
 		public static void AssertValidFilePath(string filename)
 		{
-			try
-			{
-				new FileInfo(filename);
-			}
-			catch (SecurityException)
-			{
-			}
-			catch (UnauthorizedAccessException)
-			{
-			}
+			if (!IsFilePathValid(filename))
+				throw new ArgumentException("Illegal characters in path.");
 		}
 
 		/// ------------------------------------------------------------------------------------
@@ -492,11 +484,19 @@ namespace SIL.LCModel.Utils
 		/// ------------------------------------------------------------------------------------
 		public static bool IsFilePathValid(string filename)
 		{
+			if (filename == null)
+				return false;
 			try
 			{
-				AssertValidFilePath(filename);
+				// will throw in .net framework, but not newer versions
+				var name = Path.GetFileName(filename);
+				if (name.IndexOfAny(Path.GetInvalidFileNameChars()) >= 0)
+					return false;
+				var directoryPath = filename.Substring(0, filename.Length - name.Length);
+				if (directoryPath.IndexOfAny(Path.GetInvalidPathChars()) >= 0)
+					return false;
 			}
-			catch (Exception)
+			catch
 			{
 				return false;
 			}
@@ -936,7 +936,7 @@ namespace SIL.LCModel.Utils
 		public static string ChangeWindowsPathIfLinuxPreservingPrefix(string windowsPath,
 			string prefix)
 		{
-			if (windowsPath == null || prefix == null || !windowsPath.StartsWith(prefix))
+			if (windowsPath == null || prefix == null || !windowsPath.StartsWith(prefix, StringComparison.Ordinal))
 				return ChangeWindowsPathIfLinux(windowsPath);
 			// Preserve prefix
 			windowsPath = windowsPath.Substring(prefix.Length);
@@ -975,7 +975,7 @@ namespace SIL.LCModel.Utils
 		public static string ChangeLinuxPathIfWindowsPreservingPrefix(string linuxPath,
 			string prefix)
 		{
-			if (linuxPath == null || prefix == null || !linuxPath.StartsWith(prefix))
+			if (linuxPath == null || prefix == null || !linuxPath.StartsWith(prefix, StringComparison.Ordinal))
 				return ChangeLinuxPathIfWindows(linuxPath);
 			// Preserve prefix
 			linuxPath = linuxPath.Substring(prefix.Length);

--- a/src/SIL.LCModel.Utils/FileUtils.cs
+++ b/src/SIL.LCModel.Utils/FileUtils.cs
@@ -319,7 +319,7 @@ namespace SIL.LCModel.Utils
 			byte[] fileHash2;
 
 			// compute the hashes for comparison
-			using(var hash = HashAlgorithm.Create())
+			using(var hash = HashAlgorithm.Create("SHA1"))
 			using(Stream fileStream1 = OpenStreamForRead(file1),
 							 fileStream2 = OpenStreamForRead(file2))
 			{

--- a/src/SIL.LCModel.Utils/SIL.LCModel.Utils.csproj
+++ b/src/SIL.LCModel.Utils/SIL.LCModel.Utils.csproj
@@ -10,7 +10,7 @@ SIL.LCModel.Utils provides utility classes.</Description>
   <ItemGroup>
     <PackageReference Include="GitVersion.MsBuild" Version="5.6.10" PrivateAssets="All" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
-    <PackageReference Include="SIL.Core" Version="12.0.0-*" />
+    <PackageReference Include="SIL.Core" Version="14.2.0-beta0021" />
     <PackageReference Include="SIL.ReleaseTasks" Version="2.5.0" PrivateAssets="All" />
     <PackageReference Include="Mono.Unix" Version="7.1.0-final.1.21458.1" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.2" />

--- a/src/SIL.LCModel.Utils/SIL.LCModel.Utils.csproj
+++ b/src/SIL.LCModel.Utils/SIL.LCModel.Utils.csproj
@@ -14,7 +14,7 @@ SIL.LCModel.Utils provides utility classes.</Description>
     <PackageReference Include="SIL.ReleaseTasks" Version="2.5.0" PrivateAssets="All" />
     <PackageReference Include="Mono.Unix" Version="7.1.0-final.1.21458.1" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.2" />
-    <PackageReference Include="System.Configuration.ConfigurationManager" Version="5.0.0" />
+    <PackageReference Include="System.Configuration.ConfigurationManager" Version="6.0.0" />
     <PackageReference Include="System.Diagnostics.PerformanceCounter" Version="6.0.0" />
     <PackageReference Include="System.Management" Version="6.0.0" />
     <Reference Include="System.Management" />

--- a/src/SIL.LCModel.Utils/SIL.LCModel.Utils.csproj
+++ b/src/SIL.LCModel.Utils/SIL.LCModel.Utils.csproj
@@ -10,7 +10,7 @@ SIL.LCModel.Utils provides utility classes.</Description>
   <ItemGroup>
     <PackageReference Include="GitVersion.MsBuild" Version="5.6.10" PrivateAssets="All" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
-    <PackageReference Include="SIL.Core" Version="14.2.0-beta0021" />
+    <PackageReference Include="SIL.Core" Version="14.2.0-*" />
     <PackageReference Include="SIL.ReleaseTasks" Version="2.5.0" PrivateAssets="All" />
     <PackageReference Include="Mono.Unix" Version="7.1.0-final.1.21458.1" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.2" />

--- a/src/SIL.LCModel/DomainServices/DomainObjectServices.cs
+++ b/src/SIL.LCModel/DomainServices/DomainObjectServices.cs
@@ -2298,9 +2298,7 @@ namespace SIL.LCModel.DomainServices
 			if (String.IsNullOrEmpty(srcFile))
 				throw new ArgumentException("File path not specified.", "srcFile");
 
-			char[] bad = Path.GetInvalidPathChars();
-			int idx = srcFile.IndexOfAny(bad);
-			if (idx >= 0)
+			if (!FileUtils.IsFilePathValid(srcFile))
 				throw new ArgumentException("File path (" + srcFile + ") contains at least one invalid character.", "srcFile");
 
 			foreach (ICmFile file in folder.FilesOC)

--- a/src/SIL.LCModel/LinkedFilesRelativePathHelper.cs
+++ b/src/SIL.LCModel/LinkedFilesRelativePathHelper.cs
@@ -274,6 +274,8 @@ namespace SIL.LCModel
 			try
 			{
 				var rootOfPath = Path.GetPathRoot(path);
+				// dotnet 8 on linux, when path contains invalid characters rootOfPath will be null
+				if (rootOfPath is null) return path.ToLowerInvariant();
 				return rootOfPath.ToLowerInvariant()
 					+ path.Substring(rootOfPath.Length, path.Length - rootOfPath.Length);
 			}

--- a/src/SIL.LCModel/SIL.LCModel.csproj
+++ b/src/SIL.LCModel/SIL.LCModel.csproj
@@ -22,9 +22,9 @@
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
     <PackageReference Include="protobuf-net" Version="2.4.6" />
     <PackageReference Include="SharpZipLib" Version="1.4.0" />
-    <PackageReference Include="SIL.Lexicon" Version="14.2.0-beta0021" />
+    <PackageReference Include="SIL.Lexicon" Version="14.2.0-*" />
     <PackageReference Include="SIL.ReleaseTasks" Version="2.5.0" PrivateAssets="All" />
-    <PackageReference Include="SIL.WritingSystems" Version="14.2.0-beta0021" />
+    <PackageReference Include="SIL.WritingSystems" Version="14.2.0-*" />
     <PackageReference Include="structuremap.patched" Version="4.7.3" />
     <PackageReference Include="System.ServiceProcess.ServiceController" Version="6.0.0" />
   </ItemGroup>

--- a/src/SIL.LCModel/SIL.LCModel.csproj
+++ b/src/SIL.LCModel/SIL.LCModel.csproj
@@ -22,9 +22,9 @@
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
     <PackageReference Include="protobuf-net" Version="2.4.6" />
     <PackageReference Include="SharpZipLib" Version="1.4.0" />
-    <PackageReference Include="SIL.Lexicon" Version="12.0.0-*" />
+    <PackageReference Include="SIL.Lexicon" Version="14.2.0-beta0021" />
     <PackageReference Include="SIL.ReleaseTasks" Version="2.5.0" PrivateAssets="All" />
-    <PackageReference Include="SIL.WritingSystems" Version="12.0.0-*" />
+    <PackageReference Include="SIL.WritingSystems" Version="14.2.0-beta0021" />
     <PackageReference Include="structuremap.patched" Version="4.7.3" />
     <PackageReference Include="System.ServiceProcess.ServiceController" Version="6.0.0" />
   </ItemGroup>

--- a/tests/SIL.LCModel.Core.Tests/SIL.LCModel.Core.Tests.csproj
+++ b/tests/SIL.LCModel.Core.Tests/SIL.LCModel.Core.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net461;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net461;net8.0</TargetFrameworks>
     <RootNamespace>SIL.LCModel.Core</RootNamespace>
     <Description>The liblcm library is the core FieldWorks model for linguistic analyses of languages. Tools in this library provide the ability to store and interact with language and culture data, including anthropological, text corpus, and linguistics data.
 This package provides unit tests for SIL.LCModel.Core.</Description>

--- a/tests/SIL.LCModel.Core.Tests/SIL.LCModel.Core.Tests.csproj
+++ b/tests/SIL.LCModel.Core.Tests/SIL.LCModel.Core.Tests.csproj
@@ -16,7 +16,7 @@ This package provides unit tests for SIL.LCModel.Core.</Description>
     <PackageReference Include="NUnit" Version="3.13.3" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.3.2" />
     <PackageReference Include="SIL.ReleaseTasks" Version="2.5.0" PrivateAssets="All" />
-    <PackageReference Include="SIL.TestUtilities" Version="14.2.0-beta0021" />
+    <PackageReference Include="SIL.TestUtilities" Version="14.2.0-*" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/SIL.LCModel.Core.Tests/SIL.LCModel.Core.Tests.csproj
+++ b/tests/SIL.LCModel.Core.Tests/SIL.LCModel.Core.Tests.csproj
@@ -16,7 +16,7 @@ This package provides unit tests for SIL.LCModel.Core.</Description>
     <PackageReference Include="NUnit" Version="3.13.3" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.3.2" />
     <PackageReference Include="SIL.ReleaseTasks" Version="2.5.0" PrivateAssets="All" />
-    <PackageReference Include="SIL.TestUtilities" Version="12.0.0-*" />
+    <PackageReference Include="SIL.TestUtilities" Version="14.2.0-beta0021" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/SIL.LCModel.Core.Tests/SIL.LCModel.Core.Tests.csproj
+++ b/tests/SIL.LCModel.Core.Tests/SIL.LCModel.Core.Tests.csproj
@@ -22,6 +22,7 @@ This package provides unit tests for SIL.LCModel.Core.</Description>
   <ItemGroup>
     <ProjectReference Include="..\..\src\SIL.LCModel.Core\SIL.LCModel.Core.csproj" />
     <ProjectReference Include="..\SIL.LCModel.Utils.Tests\SIL.LCModel.Utils.Tests.csproj" />
+    <ProjectReference Include="..\TestHelper\TestHelper.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/SIL.LCModel.Core.Tests/SpellChecking/SpellingHelperTests.cs
+++ b/tests/SIL.LCModel.Core.Tests/SpellChecking/SpellingHelperTests.cs
@@ -5,6 +5,7 @@
 using System;
 using System.IO;
 using System.Linq;
+using System.Runtime.InteropServices;
 using System.Text;
 using NUnit.Framework;
 using SIL.IO;
@@ -21,6 +22,17 @@ namespace SIL.LCModel.Core.SpellChecking
 	public class SpellingHelperTests
 	{
 		// TODO-Linux: need slightly modified hunspell package installed!
+
+		[OneTimeSetUp]
+		public void FixtureSetUp()
+		{
+			#if NET8_0
+			if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+			{
+				Assert.Ignore("NHunspell does not work on dotnet 8 on linux");
+			}
+			#endif
+		}
 
 		/// <summary>
 		/// Check how spelling status is set and cleared.

--- a/tests/SIL.LCModel.FixData.Tests/SIL.LCModel.FixData.Tests.csproj
+++ b/tests/SIL.LCModel.FixData.Tests/SIL.LCModel.FixData.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net461;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net461;net8.0</TargetFrameworks>
     <RootNamespace>SIL.LCModel.FixData</RootNamespace>
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/tests/SIL.LCModel.Tests/DomainImpl/CmPictureTests.cs
+++ b/tests/SIL.LCModel.Tests/DomainImpl/CmPictureTests.cs
@@ -252,7 +252,7 @@ namespace SIL.LCModel.DomainImpl
 		public void CmPictureConstructor_FromTextRep_MissingFilename()
 		{
 			Assert.That(() => m_pictureFactory.Create("CmPicture||||||This is a caption||",
-				CmFolderTags.LocalPictures), Throws.ArgumentException.With.Property("Message").Matches("File path not specified.(\\r)?\\nParameter( )?name: srcFile"));
+				CmFolderTags.LocalPictures), Throws.ArgumentException.With.Message.Contains("File path not specified"));
 		}
 
 		/// -------------------------------------------------------------------------------------

--- a/tests/SIL.LCModel.Tests/DomainServices/DataStoreInitializationServicesTests.cs
+++ b/tests/SIL.LCModel.Tests/DomainServices/DataStoreInitializationServicesTests.cs
@@ -319,10 +319,10 @@ namespace SIL.LCModel.DomainServices
 			m_para.Stub(p => p.Id).Return(paraId);
 			m_para.Contents = TsStringUtils.EmptyString(Cache.DefaultVernWs);
 
-			GetBtDelegate getBtDelegate = () =>
+			Func<ICmTranslation> getBtDelegate = () =>
 				m_para.TranslationsOC.FirstOrDefault(trans => trans.TypeRA != null &&
 					trans.TypeRA.Guid == CmPossibilityTags.kguidTranBackTranslation);
-			Mock.Get(m_para).Setup(p => p.GetBT()).Returns(getBtDelegate);
+			m_para.Stub(p => p.GetBT()).Do(getBtDelegate);
 		}
 		#endregion
 

--- a/tests/SIL.LCModel.Tests/DomainServices/DataStoreInitializationServicesTests.cs
+++ b/tests/SIL.LCModel.Tests/DomainServices/DataStoreInitializationServicesTests.cs
@@ -5,6 +5,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using Moq;
 using NUnit.Framework;
 using Rhino.Mocks;
 using SIL.LCModel.Core.KernelInterfaces;
@@ -12,6 +13,7 @@ using SIL.LCModel.Core.Scripture;
 using SIL.LCModel.Core.Text;
 using SIL.LCModel.DomainImpl;
 using SIL.LCModel.Utils;
+using MockRepository = Rhino.Mocks.MockRepository;
 
 namespace SIL.LCModel.DomainServices
 {
@@ -320,7 +322,7 @@ namespace SIL.LCModel.DomainServices
 			GetBtDelegate getBtDelegate = () =>
 				m_para.TranslationsOC.FirstOrDefault(trans => trans.TypeRA != null &&
 					trans.TypeRA.Guid == CmPossibilityTags.kguidTranBackTranslation);
-			m_para.Stub(p => p.GetBT()).Do(getBtDelegate);
+			Mock.Get(m_para).Setup(p => p.GetBT()).Returns(getBtDelegate);
 		}
 		#endregion
 

--- a/tests/SIL.LCModel.Tests/RhinoMocksToMoq/Expect.cs
+++ b/tests/SIL.LCModel.Tests/RhinoMocksToMoq/Expect.cs
@@ -1,0 +1,78 @@
+﻿using System;
+using System.Linq.Expressions;
+using Moq;
+
+namespace Rhino.Mocks
+{
+    public interface IExpect<T> where T : class
+    {
+        void Throw(Exception exception);
+    }
+
+    public interface IExpect<T, TR> where T : class
+    {
+	    IExpect<T, TR> Do(Func<TR> action);
+
+        IExpect<T, TR> Return(TR result);
+
+        void ReturnInOrder(params TR[] results);
+
+        void Throw(Exception exception);
+    }
+
+    public class Expect<T, TR> : IExpect<T, TR> where T : class
+    {
+        private readonly MoqAdapter<T, TR> _moqAdapter;
+
+        private bool _isResultAssigned;
+
+        public Expect(Mock<T> mock, Expression<Func<T, TR>> expression)
+        {
+            _moqAdapter = new MoqAdapter<T, TR>(mock, expression);
+        }
+
+        public IExpect<T, TR> Do(Func<TR> action)
+        {
+			_moqAdapter.Setup(action);
+	        return this;
+        }
+
+        public IExpect<T, TR> Return(TR result)
+        {
+            if (_isResultAssigned)
+            {
+                throw new InvalidOperationException("Return should be setup only once");
+            }
+
+            _isResultAssigned = true;
+
+            _moqAdapter.Setup(result);
+            return this;
+        }
+
+        public void Throw(Exception exception)
+        {
+            _moqAdapter.Throws(exception);
+        }
+
+        public void ReturnInOrder(params TR[] results)
+        {
+            _moqAdapter.SetupReturnInOrder(results);
+        }
+    }
+
+    public class Expect<T> : IExpect<T> where T : class
+    {
+        private readonly MoqAdapter<T> _mockAdapter;
+
+        public Expect(Mock<T> mock, Expression<Action<T>> expression)
+        {
+            _mockAdapter = new MoqAdapter<T>(mock, expression);
+        }
+
+        public void Throw(Exception exception)
+        {
+            _mockAdapter.Throws(exception);
+        }
+    }
+}

--- a/tests/SIL.LCModel.Tests/RhinoMocksToMoq/LICENSE
+++ b/tests/SIL.LCModel.Tests/RhinoMocksToMoq/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2020 Minh Nguyen
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/tests/SIL.LCModel.Tests/RhinoMocksToMoq/MockExtensions.cs
+++ b/tests/SIL.LCModel.Tests/RhinoMocksToMoq/MockExtensions.cs
@@ -1,0 +1,39 @@
+﻿using System;
+using System.Linq.Expressions;
+using Moq;
+
+namespace Rhino.Mocks
+{
+    public static class MockExtensions
+    {
+        public static IExpect<T, TR> Expect<T, TR>(this T obj, Expression<Func<T, TR>> expression) where T : class
+        {
+            return Stub(obj, expression);
+        }
+
+        public static IExpect<T> Expect<T>(this T obj, Expression<Action<T>> expression) where T : class
+        {
+            return Stub(obj, expression);
+        }
+
+        public static IExpect<T, TR> Stub<T, TR>(this T obj, Expression<Func<T, TR>> expression) where T : class
+        {
+            return new Expect<T, TR>(Mock.Get(obj), expression);
+        }
+
+        public static IExpect<T> Stub<T>(this T obj, Expression<Action<T>> expression) where T : class
+        {
+            return new Expect<T>(Mock.Get(obj), expression);
+        }
+
+        public static void AssertWasNotCalled<T>(this T obj, Expression<Action<T>> expression) where T : class
+        {
+            Mock.Get(obj).Verify(expression, Times.Never);
+        }
+
+        public static void VerifyAllExpectations<T>(this T obj) where T : class
+        {
+            Mock.Get(obj).Verify();
+        }
+    }
+}

--- a/tests/SIL.LCModel.Tests/RhinoMocksToMoq/MockRepository.cs
+++ b/tests/SIL.LCModel.Tests/RhinoMocksToMoq/MockRepository.cs
@@ -17,6 +17,8 @@ namespace Rhino.Mocks
         public static T GenerateMock<T>(MockBehavior behavior = MockBehavior.Default) where T : class
         {
             var mock = new Mock<T>(behavior);
+			mock.DefaultValueProvider = DefaultValueProvider.Empty;
+            mock.SetupAllProperties();
 			return mock.Object;
         }
     }

--- a/tests/SIL.LCModel.Tests/RhinoMocksToMoq/MockRepository.cs
+++ b/tests/SIL.LCModel.Tests/RhinoMocksToMoq/MockRepository.cs
@@ -1,0 +1,23 @@
+﻿using Moq;
+
+namespace Rhino.Mocks
+{
+    public static class MockRepository
+    {
+	    public static T GenerateStub<T>() where T : class
+        {
+            return GenerateMock<T>();
+        }
+
+        public static T GenerateStrictMock<T>() where T : class
+        {
+            return GenerateMock<T>(MockBehavior.Strict);
+        }
+
+        public static T GenerateMock<T>(MockBehavior behavior = MockBehavior.Default) where T : class
+        {
+            var mock = new Mock<T>(behavior);
+			return mock.Object;
+        }
+    }
+}

--- a/tests/SIL.LCModel.Tests/RhinoMocksToMoq/MoqAdapter.cs
+++ b/tests/SIL.LCModel.Tests/RhinoMocksToMoq/MoqAdapter.cs
@@ -1,0 +1,61 @@
+using System;
+using System.Linq.Expressions;
+using Moq;
+
+namespace Rhino.Mocks
+{
+	class MoqAdapter<T, TR> where T : class
+	{
+		private readonly Mock<T> _mock;
+		private readonly Expression<Func<T, TR>> _expression;
+
+		public MoqAdapter(Mock<T> mock, Expression<Func<T, TR>> expression)
+		{
+			_mock = mock;
+			_expression = expression;
+		}
+
+		public void Setup(TR result)
+		{
+			if (result != null)
+			{
+				_mock.Setup(_expression).Returns(result);
+			}
+		}
+
+		public void Setup(Func<TR> result)
+		{
+			if (result != null)
+			{
+				_mock.Setup(_expression).Returns(result);
+			}
+		}
+
+		public void SetupReturnInOrder(params TR[] results)
+		{
+			_mock.Setup(_expression).ReturnsInOrder(results);
+		}
+
+		public void Throws(Exception exception)
+		{
+			_mock.Setup(_expression).Throws(exception);
+		}
+	}
+
+	class MoqAdapter<T> where T : class
+	{
+		private readonly Mock<T> _mock;
+		private readonly Expression<Action<T>> _expression;
+
+		public MoqAdapter(Mock<T> mock, Expression<Action<T>> expression)
+		{
+			_mock = mock;
+			_expression = expression;
+		}
+
+		public void Throws(Exception exception)
+		{
+			_mock.Setup(_expression).Throws(exception);
+		}
+	}
+}

--- a/tests/SIL.LCModel.Tests/RhinoMocksToMoq/MoqExtensions.cs
+++ b/tests/SIL.LCModel.Tests/RhinoMocksToMoq/MoqExtensions.cs
@@ -1,0 +1,21 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using Moq.Language.Flow;
+
+namespace Rhino.Mocks
+{
+    public static class MoqExtensions
+    {
+        public static IReturnsResult<TMock> ReturnsInOrder<TMock, TResult>(this ISetup<TMock, TResult> setup, params Func<TResult>[] valueFunctions) where TMock : class
+        {
+            var functionQueue = new Queue<Func<TResult>>(valueFunctions);
+            return setup.Returns(() => functionQueue.Dequeue()());
+        }
+
+        public static void ReturnsInOrder<TMock, TResult>(this ISetup<TMock, TResult> setup, TResult[] results) where TMock : class
+        {
+            ReturnsInOrder(setup, results.Select(result => new Func<TResult>(() => result)).ToArray());
+        }
+    }
+}

--- a/tests/SIL.LCModel.Tests/SIL.LCModel.Tests.csproj
+++ b/tests/SIL.LCModel.Tests/SIL.LCModel.Tests.csproj
@@ -14,7 +14,7 @@ This package provides unit tests for SIL.LCModel.</Description>
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
     <PackageReference Include="NUnit" Version="3.13.3" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.3.2" />
-    <PackageReference Include="RhinoMocks" Version="3.6.1" />
+    <PackageReference Include="RhinoMocksToMoq" Version="0.2.0"/>
     <PackageReference Include="SIL.ReleaseTasks" Version="2.5.0" PrivateAssets="All" />
   </ItemGroup>
 

--- a/tests/SIL.LCModel.Tests/SIL.LCModel.Tests.csproj
+++ b/tests/SIL.LCModel.Tests/SIL.LCModel.Tests.csproj
@@ -12,9 +12,9 @@ This package provides unit tests for SIL.LCModel.</Description>
     <PackageReference Include="GitVersion.MsBuild" Version="5.6.10" PrivateAssets="All" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
+    <PackageReference Include="Moq" Version="4.20.70" />
     <PackageReference Include="NUnit" Version="3.13.3" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.3.2" />
-    <PackageReference Include="RhinoMocksToMoq" Version="0.2.0"/>
     <PackageReference Include="SIL.ReleaseTasks" Version="2.5.0" PrivateAssets="All" />
   </ItemGroup>
 

--- a/tests/SIL.LCModel.Tests/SIL.LCModel.Tests.csproj
+++ b/tests/SIL.LCModel.Tests/SIL.LCModel.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net461;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net461;net8.0</TargetFrameworks>
     <RootNamespace>SIL.LCModel</RootNamespace>
     <Description>The liblcm library is the core FieldWorks model for linguistic analyses of languages. Tools in this library provide the ability to store and interact with language and culture data, including anthropological, text corpus, and linguistics data.
 This package provides unit tests for SIL.LCModel.</Description>

--- a/tests/SIL.LCModel.Utils.Tests/SIL.LCModel.Utils.Tests.csproj
+++ b/tests/SIL.LCModel.Utils.Tests/SIL.LCModel.Utils.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net461</TargetFramework>
+    <TargetFrameworks>net461;net8.0</TargetFrameworks>
     <RootNamespace>SIL.LCModel.Utils</RootNamespace>
     <Description>The liblcm library is the core FieldWorks model for linguistic analyses of languages. Tools in this library provide the ability to store and interact with language and culture data, including anthropological, text corpus, and linguistics data.
 This package provides unit tests for SIL.LCModel.Utils and test utility classes</Description>

--- a/tests/TestHelper/TestHelper.csproj
+++ b/tests/TestHelper/TestHelper.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net461;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net461;net8.0</TargetFrameworks>
     <RootNamespace>Icu.Tests</RootNamespace>
     <Description>TestHelper</Description>
     <IsPackable>false</IsPackable>

--- a/tests/TestHelper/TestHelper.csproj
+++ b/tests/TestHelper/TestHelper.csproj
@@ -6,6 +6,7 @@
     <Description>TestHelper</Description>
     <IsPackable>false</IsPackable>
     <OutputType>Exe</OutputType>
+    <UpdateAssemblyInfo>false</UpdateAssemblyInfo>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Our team is planning to use LCM on dotnet 8, so I decided it would be good to run tests against dotnet 8. In doing so I found a few issues with some paths which would cause errors during build or clean.

Prevously RhinoMocks was being used however it does not support modern dotnet, Moq is the suggested replacement and I found a library that works as a shim, so I didn't need to rewrite any of the test code (with one exception).

Lastly I had to make Core and TestHelper target net8.0 also as tests would not get the desired IcuData and other dependancies otherwise.

Actual code changes:
* FileUtils.AreFilesIdentical now always uses SHA1 as the hash algorithm as modern dotnet throws if you try to delegate to a default algorithm and SHA1 is what was being used in framework
* AssertValidFilePath and IsFilePathValid had to be rewritten since modern dotnet does not do much if any validation anymore.

There's currently some failing tests due to [NHunspell](https://www.nuget.org/packages/NHunspell) not supporting anything but .Net framework and it's last update was 2015. I suggest we go to https://github.com/aarondandy/WeCantSpell.Hunspell as it's been updated in the last year and supporst .net standard 2.0. However I think that's out of scope for this PR.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/liblcm/306)
<!-- Reviewable:end -->
