### PR TITLE
Fix crash in CopyTo when fluffing up objects

### DIFF
--- a/src/SIL.LCModel/DomainImpl/Vectors.cs
+++ b/src/SIL.LCModel/DomainImpl/Vectors.cs
@@ -425,7 +425,7 @@ namespace SIL.LCModel.DomainImpl
 					throw new ArgumentOutOfRangeException("arrayIndex");
 
 				int currentcopiedIndex = arrayIndex;
-				foreach (var cmObjectOrId in m_items)
+				foreach (var cmObjectOrId in m_items.ToArray()) // ToArray to avoid collection modified exception on object FluffUp
 				{
 					array[currentcopiedIndex++] = FluffUpObjectIfNeeded(cmObjectOrId);
 				}


### PR DESCRIPTION
- FluffUpObjectIfNeeded can modify the set during iteration

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/liblcm/308)
<!-- Reviewable:end -->
