### PR TITLE
Add T Create(Guid) to ILcmFactory<T>

### DIFF
--- a/src/SIL.LCModel/DomainImpl/FactoryAdditions.cs
+++ b/src/SIL.LCModel/DomainImpl/FactoryAdditions.cs
@@ -2137,20 +2137,6 @@ namespace SIL.LCModel.DomainImpl
 					return;
 			}
 		}
-
-		/// <summary>
-		/// Create a new entry with the given guid.
-		/// </summary>
-		public ICmPicture Create(Guid guid)
-		{
-			if (guid == Guid.Empty)
-				return Create();
-
-			int hvo = ((IDataReader) m_cache.ServiceLocator.GetInstance<IDataSetup>())
-				.GetNextRealHvo();
-			return new CmPicture(m_cache, hvo, guid);
-		}
-
 	}
 	#endregion
 

--- a/src/SIL.LCModel/FactoryInterfaceAdditions.cs
+++ b/src/SIL.LCModel/FactoryInterfaceAdditions.cs
@@ -845,11 +845,6 @@ namespace SIL.LCModel
 		ICmPicture Create(string sFolder, int anchorLoc, IPictureLocationBridge locationParser,
 			string sDescription, string srcFilename, string sLayoutPos, string sLocationRange,
 			string sCopyright, string sCaption,	PictureLocationRangeType locRangeType, string sScaleFactor);
-
-		/// <summary>
-		/// Create a new entry with the given guid.
-		/// </summary>
-		ICmPicture Create(Guid guid);
 	}
 
 	/// <summary>

--- a/src/SIL.LCModel/ILcmServiceLocator.cs
+++ b/src/SIL.LCModel/ILcmServiceLocator.cs
@@ -96,6 +96,7 @@ namespace SIL.LCModel
 		IdentityMap IdentityMap { get; }
 		LoadingServices LoadingServices { get; }
 		IUnitOfWorkService UnitOfWorkService { get; }
+		IDataReader DataReader { get; }
 	}
 
 	/// <summary>

--- a/src/SIL.LCModel/IOC/LcmServiceLocatorFactory.cs
+++ b/src/SIL.LCModel/IOC/LcmServiceLocatorFactory.cs
@@ -430,6 +430,14 @@ namespace SIL.LCModel.IOC
 			}
 		}
 
+		public IDataReader DataReader
+		{
+			get
+			{
+				return GetInstance<IDataReader>();
+			}
+		}
+
 		/// <summary>
 		/// Get the specified object instance; short for getting ICmObjectRepository and asking it to GetObject.
 		/// </summary>

--- a/src/SIL.LCModel/InterfaceDeclarations.cs
+++ b/src/SIL.LCModel/InterfaceDeclarations.cs
@@ -638,6 +638,12 @@ namespace SIL.LCModel
 		/// </summary>
 		/// <returns>A new, unowned, ICmObject with a Guid, but no Hvo.</returns>
 		T Create();
+
+		/// <summary>
+		/// Basic creation method for an ICmObject with the given guid.
+		/// </summary>
+		/// <returns>A new, unowned, ICmObject with the given guid.</returns>
+		T Create(Guid guid);
 	}
 	#endregion
 

--- a/src/SIL.LCModel/LcmCache.cs
+++ b/src/SIL.LCModel/LcmCache.cs
@@ -1085,6 +1085,11 @@ namespace SIL.LCModel
 			get { return m_serviceLocator; }
 		}
 
+		internal IServiceLocatorInternal InternalServices
+		{
+			get { return (IServiceLocatorInternal) m_serviceLocator; }
+		}
+
 		/// <summary>
 		/// Add to the list a ClassAndPropInfo for each concrete class of object that may be added to
 		/// property flid.

--- a/src/SIL.LCModel/LcmGenerate/factory.vm.cs
+++ b/src/SIL.LCModel/LcmGenerate/factory.vm.cs
@@ -64,7 +64,7 @@
 			if (m_cache.ServiceLocator.GetInstance<I${className}Repository>().Singleton != null)
 				throw new InvalidOperationException("Can not create more than one ${className}");
 #end
-			if (guid == Guid.Empty) throw new ArgumentException("Can not create a new ${className} with an empty guid.");
+			if (guid == Guid.Empty) guid = Guid.NewGuid();
 			int hvo = m_cache.InternalServices.DataReader.GetNextRealHvo();
 			var newby = new $className(m_cache, hvo, guid);
 #if ( $ownerStatus != "required")

--- a/src/SIL.LCModel/LcmGenerate/factory.vm.cs
+++ b/src/SIL.LCModel/LcmGenerate/factory.vm.cs
@@ -10,6 +10,7 @@
 ## --------------------------------------------------------------------------------------------
 #set( $className = $class.Name )
 #set( $baseClassName = $class.BaseClass.Name )
+#set( $ownerStatus = $class.OwnerStatus )
 #if ($class.Name == "LgWritingSystem")
 #set( $classSfx = "FactoryLcm" )
 #else
@@ -50,6 +51,25 @@
 			var newby = new $className();
 			if (newby.OwnershipStatus != ClassOwnershipStatus.kOwnerRequired)
 				((ICmObjectInternal)newby).InitializeNewOwnerlessCmObject(m_cache);
+			return newby;
+		}
+
+		/// <summary>
+		/// Basic creation method for an $className.
+		/// </summary>
+		/// <returns>A new, unowned, $className with the given guid.</returns>
+		public I$className Create(Guid guid)
+		{
+#if ($class.IsSingleton)
+			if (m_cache.ServiceLocator.GetInstance<I${className}Repository>().Singleton != null)
+				throw new InvalidOperationException("Can not create more than one ${className}");
+#end
+			if (guid == Guid.Empty) throw new ArgumentException("Can not create a new ${className} with an empty guid.");
+			int hvo = m_cache.InternalServices.DataReader.GetNextRealHvo();
+			var newby = new $className(m_cache, hvo, guid);
+#if ( $ownerStatus != "required")
+			((ICmObjectInternal) newby).InitializeNewOwnerlessCmObjectWithPresetGuid();
+#end
 			return newby;
 		}
 #end

--- a/tests/SIL.LCModel.Tests/Infrastructure/Impl/LexEntryTypeTests.cs
+++ b/tests/SIL.LCModel.Tests/Infrastructure/Impl/LexEntryTypeTests.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using System.Linq;
+using NUnit.Framework;
+
+namespace SIL.LCModel.Infrastructure.Impl
+{
+	public class LexEntryTypeTests: MemoryOnlyBackendProviderRestoredForEachTestTestBase
+	{
+		[Test]
+		public void CreateTypeWithGuid_CanAddToList()
+		{
+			var guid = Guid.NewGuid();
+			var lexEntryType = Cache.ServiceLocator.GetInstance<ILexEntryTypeFactory>().Create(guid);
+
+			Cache.LangProject.LexDbOA.ComplexEntryTypesOA.PossibilitiesOS.Add(lexEntryType);
+
+			Assert.That(Cache.ServiceLocator.ObjectRepository.GetObject(guid), Is.EqualTo(lexEntryType));
+		}
+	}
+}


### PR DESCRIPTION
Right now to make a given object with a specific GUID you need to use a specialized factory method, this PR adds a low lever API to make any object with a predefined GUID.

There was a conflict with ICmPictureFactory because it declared it's own version with the same signature which I then had to remove from the actual CmPictureFactory.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/liblcm/313)
<!-- Reviewable:end -->
