### PR TITLE
Rename Rhino.Mocks to SIL.LCModel.Tests.Rhino.Mocks

### DIFF
--- a/tests/SIL.LCModel.Tests/DomainImpl/ScrImportSetTests.cs
+++ b/tests/SIL.LCModel.Tests/DomainImpl/ScrImportSetTests.cs
@@ -6,7 +6,7 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using NUnit.Framework;
-using Rhino.Mocks;
+using SIL.LCModel.Tests.Rhino.Mocks;
 using SIL.LCModel.Core.Scripture;
 using SIL.LCModel.DomainServices;
 using SIL.LCModel.Utils;

--- a/tests/SIL.LCModel.Tests/DomainImpl/ScrMappingListTests.cs
+++ b/tests/SIL.LCModel.Tests/DomainImpl/ScrMappingListTests.cs
@@ -5,7 +5,7 @@
 using System;
 using System.IO;
 using NUnit.Framework;
-using Rhino.Mocks;
+using SIL.LCModel.Tests.Rhino.Mocks;
 using SIL.LCModel.Core.KernelInterfaces;
 using SIL.LCModel.Core.Scripture;
 using SIL.LCModel.DomainServices;

--- a/tests/SIL.LCModel.Tests/DomainImpl/VectorTests.cs
+++ b/tests/SIL.LCModel.Tests/DomainImpl/VectorTests.cs
@@ -9,7 +9,7 @@
 using System;
 using System.Linq;
 using NUnit.Framework;
-using Rhino.Mocks;
+using SIL.LCModel.Tests.Rhino.Mocks;
 using SIL.LCModel.Core.Scripture;
 using SIL.LCModel.Core.Text;
 using SIL.LCModel.Infrastructure;

--- a/tests/SIL.LCModel.Tests/DomainServices/DataStoreInitializationServicesTests.cs
+++ b/tests/SIL.LCModel.Tests/DomainServices/DataStoreInitializationServicesTests.cs
@@ -5,15 +5,13 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using Moq;
 using NUnit.Framework;
-using Rhino.Mocks;
+using SIL.LCModel.Tests.Rhino.Mocks;
 using SIL.LCModel.Core.KernelInterfaces;
 using SIL.LCModel.Core.Scripture;
 using SIL.LCModel.Core.Text;
 using SIL.LCModel.DomainImpl;
 using SIL.LCModel.Utils;
-using MockRepository = Rhino.Mocks.MockRepository;
 
 namespace SIL.LCModel.DomainServices
 {

--- a/tests/SIL.LCModel.Tests/DomainServices/ScrSfFileListTests.cs
+++ b/tests/SIL.LCModel.Tests/DomainServices/ScrSfFileListTests.cs
@@ -4,7 +4,7 @@
 
 using System.Collections.Generic;
 using NUnit.Framework;
-using Rhino.Mocks;
+using SIL.LCModel.Tests.Rhino.Mocks;
 using SIL.LCModel.Core.Scripture;
 using SIL.LCModel.DomainImpl;
 

--- a/tests/SIL.LCModel.Tests/Infrastructure/Impl/IActionHandlerTests.cs
+++ b/tests/SIL.LCModel.Tests/Infrastructure/Impl/IActionHandlerTests.cs
@@ -6,7 +6,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using NUnit.Framework;
-using Rhino.Mocks;
+using SIL.LCModel.Tests.Rhino.Mocks;
 using SIL.LCModel.Application;
 using SIL.LCModel.Core.Cellar;
 using SIL.LCModel.Core.KernelInterfaces;

--- a/tests/SIL.LCModel.Tests/RhinoMocksToMoq/Expect.cs
+++ b/tests/SIL.LCModel.Tests/RhinoMocksToMoq/Expect.cs
@@ -1,8 +1,8 @@
-﻿using System;
+using System;
 using System.Linq.Expressions;
 using Moq;
 
-namespace Rhino.Mocks
+namespace SIL.LCModel.Tests.Rhino.Mocks
 {
     public interface IExpect<T> where T : class
     {

--- a/tests/SIL.LCModel.Tests/RhinoMocksToMoq/MockExtensions.cs
+++ b/tests/SIL.LCModel.Tests/RhinoMocksToMoq/MockExtensions.cs
@@ -1,8 +1,8 @@
-﻿using System;
+using System;
 using System.Linq.Expressions;
 using Moq;
 
-namespace Rhino.Mocks
+namespace SIL.LCModel.Tests.Rhino.Mocks
 {
     public static class MockExtensions
     {

--- a/tests/SIL.LCModel.Tests/RhinoMocksToMoq/MockRepository.cs
+++ b/tests/SIL.LCModel.Tests/RhinoMocksToMoq/MockRepository.cs
@@ -1,6 +1,6 @@
-﻿using Moq;
+using Moq;
 
-namespace Rhino.Mocks
+namespace SIL.LCModel.Tests.Rhino.Mocks
 {
     public static class MockRepository
     {

--- a/tests/SIL.LCModel.Tests/RhinoMocksToMoq/MoqAdapter.cs
+++ b/tests/SIL.LCModel.Tests/RhinoMocksToMoq/MoqAdapter.cs
@@ -2,7 +2,7 @@ using System;
 using System.Linq.Expressions;
 using Moq;
 
-namespace Rhino.Mocks
+namespace SIL.LCModel.Tests.Rhino.Mocks
 {
 	class MoqAdapter<T, TR> where T : class
 	{

--- a/tests/SIL.LCModel.Tests/RhinoMocksToMoq/MoqExtensions.cs
+++ b/tests/SIL.LCModel.Tests/RhinoMocksToMoq/MoqExtensions.cs
@@ -1,9 +1,9 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using Moq.Language.Flow;
 
-namespace Rhino.Mocks
+namespace SIL.LCModel.Tests.Rhino.Mocks
 {
     public static class MoqExtensions
     {


### PR DESCRIPTION
I renamed the local Rhino.Mocks per Jason so that it wouldn't conflict with FieldWorks' use of Rhino.Mocks.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/liblcm/314)
<!-- Reviewable:end -->
