### PR TITLE
LT-9222: "***" appearing between inflectional features and values

### DIFF
--- a/src/SIL.LCModel/DomainImpl/OverridesCellar.cs
+++ b/src/SIL.LCModel/DomainImpl/OverridesCellar.cs
@@ -2275,7 +2275,12 @@ namespace SIL.LCModel.DomainImpl
 					if (sValue == null || sValue.Length == 0)
 						sValue = ValueRA.Name.BestAnalysisAlternative.Text;
 					if (!fLongForm)
-						sValue = sValue + ValueRA.RightGlossSep.AnalysisDefaultWritingSystem.Text;
+					{
+						string sep = ValueRA.RightGlossSep.AnalysisDefaultWritingSystem.Text;
+						if (sep == "***")
+							sep = ":";
+						sValue = sValue + sep;
+					}
 				}
 			}
 			else
@@ -2296,7 +2301,12 @@ namespace SIL.LCModel.DomainImpl
 					if (fLongForm)
 						sFeature = sFeature + ":";
 					else
-						sFeature = sFeature + FeatureRA.RightGlossSep.BestAnalysisAlternative.Text;
+					{
+						string sep = ValueRA.RightGlossSep.AnalysisDefaultWritingSystem.Text;
+						if (sep == "***")
+							sep = ":";
+						sFeature = sFeature + sep;
+					}
 				}
 			}
 			else
@@ -2531,7 +2541,10 @@ namespace SIL.LCModel.DomainImpl
 					sFeature = FeatureRA.Abbreviation.BestAnalysisAlternative.Text;
 					if (string.IsNullOrEmpty(sFeature))
 						sFeature = FeatureRA.Name.BestAnalysisAlternative.Text;
-					sFeature = fLongForm ? sFeature + ":" : sFeature + FeatureRA.RightGlossSep.BestAnalysisAlternative.Text;
+					string sep = fLongForm ? ":" : FeatureRA.RightGlossSep.AnalysisDefaultWritingSystem.Text;
+					if (sep == "***")
+						sep = ":";
+					sFeature = sFeature + sep;
 				}
 			}
 			else

--- a/src/SIL.LCModel/DomainImpl/OverridesCellar.cs
+++ b/src/SIL.LCModel/DomainImpl/OverridesCellar.cs
@@ -2276,21 +2276,13 @@ namespace SIL.LCModel.DomainImpl
 						sValue = ValueRA.Name.BestAnalysisAlternative.Text;
 					if (!fLongForm)
 					{
-						sValue = sValue + GetSeparator(ValueRA.RightGlossSep, fLongForm);
+						sValue = sValue + ValueRA.RightGlossSep.AnalysisDefaultWritingSystem.Text;
 					}
 				}
 			}
 			else
 				sValue = m_ksUnknown;
 			return sValue;
-		}
-
-		internal static string GetSeparator(IMultiUnicode rightGlossSep, bool longForm)
-		{
-			string sep = rightGlossSep.AnalysisDefaultWritingSystem.Text;
-			if (longForm || sep == "***")
-				return ":";
-			return sep;
 		}
 
 		private string GetFeatureString(bool fLongForm)
@@ -2303,12 +2295,20 @@ namespace SIL.LCModel.DomainImpl
 					sFeature = FeatureRA.Abbreviation.BestAnalysisAlternative.Text;
 					if (sFeature == null || sFeature.Length == 0)
 						sFeature = FeatureRA.Name.BestAnalysisAlternative.Text;
-					sFeature = sFeature + GetSeparator(FeatureRA.RightGlossSep, fLongForm);
+					sFeature = sFeature + GetSeparator(FeatureRA, fLongForm);
 				}
 			}
 			else
 				sFeature = m_ksUnknown;
 			return sFeature;
+		}
+
+		internal static string GetSeparator(IFsFeatDefn feature, bool longForm)
+		{
+			string sep = feature.RightGlossSep.BestAnalysisAlternative.Text;
+			if (longForm || sep == "***")
+				return ":";
+			return sep;
 		}
 
 		/// <summary>
@@ -2538,7 +2538,7 @@ namespace SIL.LCModel.DomainImpl
 					sFeature = FeatureRA.Abbreviation.BestAnalysisAlternative.Text;
 					if (string.IsNullOrEmpty(sFeature))
 						sFeature = FeatureRA.Name.BestAnalysisAlternative.Text;
-					sFeature = sFeature + FsClosedValue.GetSeparator(FeatureRA.RightGlossSep, fLongForm);
+					sFeature = sFeature + FsClosedValue.GetSeparator(FeatureRA, fLongForm);
 				}
 			}
 			else

--- a/src/SIL.LCModel/DomainImpl/OverridesCellar.cs
+++ b/src/SIL.LCModel/DomainImpl/OverridesCellar.cs
@@ -2275,9 +2275,7 @@ namespace SIL.LCModel.DomainImpl
 					if (sValue == null || sValue.Length == 0)
 						sValue = ValueRA.Name.BestAnalysisAlternative.Text;
 					if (!fLongForm)
-					{
 						sValue = sValue + ValueRA.RightGlossSep.AnalysisDefaultWritingSystem.Text;
-					}
 				}
 			}
 			else

--- a/src/SIL.LCModel/DomainImpl/OverridesCellar.cs
+++ b/src/SIL.LCModel/DomainImpl/OverridesCellar.cs
@@ -2276,16 +2276,21 @@ namespace SIL.LCModel.DomainImpl
 						sValue = ValueRA.Name.BestAnalysisAlternative.Text;
 					if (!fLongForm)
 					{
-						string sep = ValueRA.RightGlossSep.AnalysisDefaultWritingSystem.Text;
-						if (sep == "***")
-							sep = ":";
-						sValue = sValue + sep;
+						sValue = sValue + GetSeparator(ValueRA.RightGlossSep, fLongForm);
 					}
 				}
 			}
 			else
 				sValue = m_ksUnknown;
 			return sValue;
+		}
+
+		internal static string GetSeparator(IMultiUnicode rightGlossSep, bool longForm)
+		{
+			string sep = rightGlossSep.AnalysisDefaultWritingSystem.Text;
+			if (longForm || sep == "***")
+				return ":";
+			return sep;
 		}
 
 		private string GetFeatureString(bool fLongForm)
@@ -2298,15 +2303,7 @@ namespace SIL.LCModel.DomainImpl
 					sFeature = FeatureRA.Abbreviation.BestAnalysisAlternative.Text;
 					if (sFeature == null || sFeature.Length == 0)
 						sFeature = FeatureRA.Name.BestAnalysisAlternative.Text;
-					if (fLongForm)
-						sFeature = sFeature + ":";
-					else
-					{
-						string sep = ValueRA.RightGlossSep.AnalysisDefaultWritingSystem.Text;
-						if (sep == "***")
-							sep = ":";
-						sFeature = sFeature + sep;
-					}
+					sFeature = sFeature + GetSeparator(FeatureRA.RightGlossSep, fLongForm);
 				}
 			}
 			else
@@ -2541,10 +2538,7 @@ namespace SIL.LCModel.DomainImpl
 					sFeature = FeatureRA.Abbreviation.BestAnalysisAlternative.Text;
 					if (string.IsNullOrEmpty(sFeature))
 						sFeature = FeatureRA.Name.BestAnalysisAlternative.Text;
-					string sep = fLongForm ? ":" : FeatureRA.RightGlossSep.AnalysisDefaultWritingSystem.Text;
-					if (sep == "***")
-						sep = ":";
-					sFeature = sFeature + sep;
+					sFeature = sFeature + FsClosedValue.GetSeparator(FeatureRA.RightGlossSep, fLongForm);
 				}
 			}
 			else


### PR DESCRIPTION
This fixes https://jira.sil.org/browse/LT-9222 by defaulting RightGlossSep to ":" if it doesn't have a value (e.g. the value is "***").

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/liblcm/318)
<!-- Reviewable:end -->
