### PR TITLE
LT-21205: Features should obey the order set in Feature Types 

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+# Test
 # LCModel Library
 
 ## Description

--- a/src/SIL.LCModel/DomainImpl/OverridesCellar.cs
+++ b/src/SIL.LCModel/DomainImpl/OverridesCellar.cs
@@ -2460,7 +2460,7 @@ namespace SIL.LCModel.DomainImpl
 		{
 			get
 			{
-				return GetFeatureValueStringSorted();
+				return GetFeatureValueString(true);
 			}
 		}
 		/// <summary>
@@ -2491,17 +2491,6 @@ namespace SIL.LCModel.DomainImpl
 			var sValue = GetValueString(fLongForm);
 			tisb.Append(sFeature);
 			tisb.Append(sValue);
-			return tisb.GetString();
-		}
-
-		private ITsString GetFeatureValueStringSorted()
-		{
-			var tisb = TsStringUtils.MakeIncStrBldr();
-			tisb.SetIntPropValues((int)FwTextPropType.ktptWs,
-				0, Cache.DefaultAnalWs);
-			var sFeature = GetFeatureString(true);
-			tisb.Append(sFeature);
-			tisb.AppendTsString((ValueOA as FsFeatStruc).GetFeatureValueStringSorted());
 			return tisb.GetString();
 		}
 
@@ -3794,7 +3783,7 @@ namespace SIL.LCModel.DomainImpl
 		{
 			get
 			{
-				return GetFeatureValueStringSorted();
+				return GetFeatureValueString(true);
 			}
 		}
 		/// <summary>
@@ -4012,56 +4001,6 @@ namespace SIL.LCModel.DomainImpl
 			return "1" + spec.FeatureRA.Name.BestAnalysisAlternative.Text;
 		}
 
-		internal ITsString GetFeatureValueStringSorted()
-		{
-			var tisb = TsStringUtils.MakeIncStrBldr();
-			var iCount = FeatureSpecsOC.Count;
-			if (iCount > 0)
-			{
-				tisb.SetIntPropValues((int)FwTextPropType.ktptWs, (int)FwTextPropVar.ktpvDefault,
-					m_cache.DefaultAnalWs);
-				tisb.Append("[");
-			}
-			var count = 0;
-			var sortedSpecs = from s in FeatureSpecsOC
-							  orderby s.FeatureRA.Name.BestAnalysisAlternative.Text
-							  select s;
-			foreach (var spec in sortedSpecs)
-			{
-				if (count++ > 0)
-				{
-					tisb.SetIntPropValues((int)FwTextPropType.ktptWs, (int)FwTextPropVar.ktpvDefault,
-						m_cache.DefaultAnalWs);
-					tisb.Append(" "); // insert space except for first item
-				}
-				var cv = spec as IFsClosedValue;
-				if (cv != null)
-				{
-						tisb.AppendTsString((cv as FsClosedValue).LongNameTSS);
-				}
-				else
-				{
-					var complex = spec as IFsComplexValue;
-					if (complex != null)
-					{
-							tisb.AppendTsString((complex as FsComplexValue).LongNameSortedTSS);
-					}
-				}
-			}
-			if (iCount > 0)
-			{
-				tisb.SetIntPropValues((int)FwTextPropType.ktptWs, (int)FwTextPropVar.ktpvDefault,
-					m_cache.DefaultAnalWs);
-				tisb.Append("]");
-			}
-			if (tisb.Text == null)
-			{
-				// Ensure that we have a ws for the empty string!  See FWR-1122.
-				tisb.SetIntPropValues((int)FwTextPropType.ktptWs, (int)FwTextPropVar.ktpvDefault,
-					m_cache.DefaultAnalWs);
-			}
-			return tisb.GetString();
-		}
 		/// <summary>
 		/// Provide a "Name" for this (is a long name)
 		/// </summary>

--- a/src/SIL.LCModel/DomainImpl/OverridesCellar.cs
+++ b/src/SIL.LCModel/DomainImpl/OverridesCellar.cs
@@ -3947,7 +3947,10 @@ namespace SIL.LCModel.DomainImpl
 				tisb.Append("[");
 			}
 			var count = 0;
-			foreach (var spec in FeatureSpecsOC)
+			var sortedSpecs = from s in FeatureSpecsOC
+							  orderby FeatureSpecKey(s)
+							  select s;
+			foreach (var spec in sortedSpecs)
 			{
 				if (count++ > 0)
 				{
@@ -3992,6 +3995,21 @@ namespace SIL.LCModel.DomainImpl
 					m_cache.DefaultAnalWs);
 			}
 			return tisb.GetString();
+		}
+
+		private string FeatureSpecKey(IFsFeatureSpecification spec)
+		{
+			if (spec.FeatureRA == null)
+				return "";
+			if (TypeRA != null)
+			{
+				int index = TypeRA.FeaturesRS.IndexOf(spec.FeatureRA);
+				if (index >= 0)
+				{
+					return index.ToString("000");
+				}
+			}
+			return "1" + spec.FeatureRA.Name.BestAnalysisAlternative.Text;
 		}
 
 		internal ITsString GetFeatureValueStringSorted()

--- a/tests/SIL.LCModel.Tests/DomainImpl/CellarTests.cs
+++ b/tests/SIL.LCModel.Tests/DomainImpl/CellarTests.cs
@@ -640,7 +640,7 @@ namespace SIL.LCModel.DomainImpl
 			pos.AddInflectableFeatsFromXml(itemAorist);
 			featStruct.AddFeatureFromXml(itemAorist, msfs);
 			// Check for correct LongName
-			Assert.AreEqual("[sbj:[gen:f pers:1] asp:aor]", featStruct.LongName, "Incorrect LongName for complex and closed");
+			Assert.AreEqual("[asp:aor sbj:[gen:f pers:1]]", featStruct.LongName, "Incorrect LongName for complex and closed");
 			// Now add the features in the featurs struct in a different order
 			pos.DefaultFeaturesOA = null;
 			pos.DefaultFeaturesOA = Cache.ServiceLocator.GetInstance<IFsFeatStrucFactory>().Create();
@@ -649,9 +649,9 @@ namespace SIL.LCModel.DomainImpl
 			featStruct.AddFeatureFromXml(item1st, msfs);
 			featStruct.AddFeatureFromXml(itemFem, msfs);
 			// check for correct short name
-			Assert.AreEqual("aor 1 f", featStruct.ShortName, "Incorrect ShortName for complex");
+			Assert.AreEqual("aor f 1", featStruct.ShortName, "Incorrect ShortName for complex");
 			// Check for correct LongName
-			Assert.AreEqual("[asp:aor sbj:[pers:1 gen:f]]", featStruct.LongName, "Incorrect LongName for complex and closed");
+			Assert.AreEqual("[asp:aor sbj:[gen:f pers:1]]", featStruct.LongName, "Incorrect LongName for complex and closed");
 			// Now create another feature structure with different values and merge it into the first feature structure
 			pos.InherFeatValOA = Cache.ServiceLocator.GetInstance<IFsFeatStrucFactory>().Create();
 			IFsFeatStruc featStruct2 = pos.InherFeatValOA;
@@ -665,7 +665,7 @@ namespace SIL.LCModel.DomainImpl
 			featStruct2.AddFeatureFromXml(itemSg, msfs);
 			featStruct.PriorityUnion(featStruct2);
 			// Check for correct LongName
-			Assert.AreEqual("[asp:aor sbj:[pers:1 gen:n num:sg]]", featStruct.LongName, "Incorrect LongName for merged feature struture");
+			Assert.AreEqual("[asp:aor sbj:[gen:n num:sg pers:1]]", featStruct.LongName, "Incorrect LongName for merged feature struture");
 			Assert.AreEqual("[asp:aor sbj:[gen:n num:sg pers:1]]", featStruct.LongNameSorted, "Incorrect LongNameSorted for merged feature struture");
 		}
 


### PR DESCRIPTION
This fixes https://jira.sil.org/browse/LT-21205 by changing LongName to sort features based on the order in the type with any remaining features sorted alphabetically afterwards.  I also made LongNameSorted use the same code as LongName.