### PR TITLE
Fix LT-21206: Features label misleading: "Show Abbr as label"

### DIFF
--- a/src/SIL.LCModel/DomainImpl/OverridesCellar.cs
+++ b/src/SIL.LCModel/DomainImpl/OverridesCellar.cs
@@ -2269,14 +2269,20 @@ namespace SIL.LCModel.DomainImpl
 			var sValue = "";
 			if (ValueRA != null)
 			{
-				if (fLongForm || ValueRA.ShowInGloss)
+				// per LT-21206, ShowInGloss now means "show as abbreviation".
+				// If ShowInGloss is false, then use the name instead.
+				if (ValueRA.ShowInGloss)
 				{
 					sValue = ValueRA.Abbreviation.BestAnalysisAlternative.Text;
 					if (sValue == null || sValue.Length == 0)
 						sValue = ValueRA.Name.BestAnalysisAlternative.Text;
-					if (!fLongForm)
-						sValue = sValue + ValueRA.RightGlossSep.AnalysisDefaultWritingSystem.Text;
 				}
+				else
+				{
+					sValue = ValueRA.Name.BestAnalysisAlternative.Text;
+				}
+				if (!fLongForm)
+					sValue = sValue + ValueRA.RightGlossSep.AnalysisDefaultWritingSystem.Text;
 			}
 			else
 				sValue = m_ksUnknown;


### PR DESCRIPTION
As part of https://jira.sil.org/browse/LT-21206, Beth requested that "On the Values, please change the functionality [of Show Abbreviation as Label] to allow it to show either the Name or the Abbreviation.  (I need to research whether a user might not want the value itself to show at all)".  I checked with Beth, and she hasn't done the research but wants to go ahead with this change and add an option later if somebody asks for it.

So, I changed GetValueString to use Name if ValueRA.ShowInGloss is false. 

This should be part of release/9.3.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/liblcm/321)
<!-- Reviewable:end -->
