### PR TITLE
Fix LT-21729: Crash deleting phoneme features set

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,3 @@
-
 # LCModel Library
 
 ## Description

--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+
 # LCModel Library
 
 ## Description

--- a/src/SIL.LCModel/DomainImpl/OverridesLing_Lex.cs
+++ b/src/SIL.LCModel/DomainImpl/OverridesLing_Lex.cs
@@ -7644,15 +7644,23 @@ namespace SIL.LCModel.DomainImpl
 				if (removedCtxt != null)
 				{
 					var featConstrs = GetFeatureConstraintsExcept(removedCtxt);
-					foreach (var constr in removedCtxt.PlusConstrRS)
+					foreach (var constr in removedCtxt.PlusConstrRS.ToList())
 					{
 						if (!featConstrs.Contains(constr))
+						{
+							// Remove constr from removedCtxt first to avoid deleting removedCtxt twice (fixes LT-21729).
+							removedCtxt.PlusConstrRS.Remove(constr);
 							m_cache.LanguageProject.PhonologicalDataOA.FeatConstraintsOS.Remove(constr);
+						}
 					}
-					foreach (var constr in removedCtxt.MinusConstrRS)
+					foreach (var constr in removedCtxt.MinusConstrRS.ToList())
 					{
 						if (!featConstrs.Contains(constr))
+						{
+							// Remove constr from removedCtxt first to avoid deleting removedCtxt twice.
+							removedCtxt.MinusConstrRS.Remove(constr);
 							m_cache.LanguageProject.PhonologicalDataOA.FeatConstraintsOS.Remove(constr);
+						}
 					}
 				}
 			}


### PR DESCRIPTION
Deleting a phonological feature set from a rule caused a crash if one of the feature values is "agree" because in the process of deleting the feature set context RemoveObjectSideEffectsInternal deletes the feature values with "agree" and "disagree" from LanguageProject.PhonologicalDataOA.FeatConstraintsOS, and the code for doing that deletes the referring feature set context.  So the feature set context gets deleted twice, causing a crash.  I avoid this by removing the feature constraint from the context before deleting it from FeatConstraintsOS.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/liblcm/322)
<!-- Reviewable:end -->
