### PR TITLE
Fix LT-22032: Make valid character dialog more valid

### DIFF
--- a/src/SIL.LCModel.Core/Text/UcdProperty.cs
+++ b/src/SIL.LCModel.Core/Text/UcdProperty.cs
@@ -208,7 +208,7 @@ namespace SIL.LCModel.Core.Text
 		#region static accessor functions
 		/// ------------------------------------------------------------------------------------
 		/// <summary>
-		/// Fills a two-tiered hash table system with all the instances of this class that
+		/// Fills a two-tiered hash table system with all the categories and classes we expect
 		/// </summary>
 		/// ------------------------------------------------------------------------------------
 		private static void InitializeHashTables()
@@ -302,6 +302,8 @@ namespace SIL.LCModel.Core.Text
 					new UcdProperty("0", UcdCategories.canonicalCombiningClass));
 				canonicalCombiningClassDict.Add(1,
 					new UcdProperty("1", UcdCategories.canonicalCombiningClass));
+				canonicalCombiningClassDict.Add(2,
+					new UcdProperty("2", UcdCategories.canonicalCombiningClass));
 				canonicalCombiningClassDict.Add(7,
 					new UcdProperty("7", UcdCategories.canonicalCombiningClass));
 				canonicalCombiningClassDict.Add(8,


### PR DESCRIPTION
* There was a valid class of combining character categories related to extended whitespace not yet handled

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/liblcm/323)
<!-- Reviewable:end -->
