### PR TITLE
Fix LT-22110: Intermittent crash in Segment.get_AnalysesRS

### DIFF
--- a/src/SIL.LCModel/DomainServices/AnalysisGuessServices.cs
+++ b/src/SIL.LCModel/DomainServices/AnalysisGuessServices.cs
@@ -402,6 +402,7 @@ namespace SIL.LCModel.DomainServices
 			var segs = new HashSet<ISegment>();
 			foreach (ISegment seg in wordform.OccurrencesInTexts)
 			{
+				if (!seg.IsValidObject) continue;
 				if (segs.Contains(seg)) continue;
 				segs.Add(seg);
 				for (int i = 0; i < seg.AnalysesRS.Count; i++)
@@ -462,6 +463,7 @@ namespace SIL.LCModel.DomainServices
 				return counts;
 			foreach (ISegment seg in analysis.Wordform.OccurrencesInTexts)
 			{
+				if (!seg.IsValidObject) continue;
 				if (segs.Contains(seg)) continue;
 				segs.Add(seg);
 				for (int i = 0; i < seg.AnalysesRS.Count; i++)
@@ -731,6 +733,8 @@ namespace SIL.LCModel.DomainServices
 			if (occurrence == null)
 				return null;
 			if (onlyIndexZeroLowercaseMatching && occurrence.Index != 0)
+				return null;
+			if (occurrence.Segment == null || !occurrence.Segment.IsValidObject)
 				return null;
 			ITsString tssWfBaseline = occurrence.BaselineText;
 			var cf = new CaseFunctions(Cache.ServiceLocator.WritingSystemManager.Get(ws));

--- a/src/SIL.LCModel/DomainServices/AnalysisOccurrence.cs
+++ b/src/SIL.LCModel/DomainServices/AnalysisOccurrence.cs
@@ -56,7 +56,7 @@ namespace SIL.LCModel.DomainServices
 		{
 			get
 			{
-				if (Segment?.AnalysesRS != null && Index < Segment.AnalysesRS.Count)
+				if (Segment != null && Segment.IsValidObject && Segment.AnalysesRS != null && Index < Segment.AnalysesRS.Count)
 					return Segment.AnalysesRS[Index];
 				return null;
 			}


### PR DESCRIPTION
If a Segment is no longer valid, then Segment.AnalysesRS crashes.  This tends to happen if the user edits the baseline text after analyzing some of the text.  This happens to Mark Bean a lot.  I fixed all of the places that he got a crash, but there are hundreds of references to Segent.AnalysesRS in liblcm.  It would be nice if Segment.AnalysesRS could return a dummy AnalysesRS or something when the Segment is not valid to avoid crashes.