### PR TITLE
Fix LT-22121: Analysis guesser should not guess ras for rAs

### DIFF
--- a/tests/SIL.LCModel.Tests/DomainServices/AnalysisGuessServicesTests.cs
+++ b/tests/SIL.LCModel.Tests/DomainServices/AnalysisGuessServicesTests.cs
@@ -170,6 +170,17 @@ namespace SIL.LCModel.DomainServices
 					" " + Words_para0[4].Form.BestVernacularAlternative.Text +
 					".", wsVern));
 				Para0.Contents = bldr4.GetString();
+				/* rAs ras */
+				IWfiWordform rAs = wfFactory.Create(TsStringUtils.MakeString("rAs", wsVern));
+				Words_para0.Add(rAs);
+				IWfiWordform ras = wfFactory.Create(TsStringUtils.MakeString("ras", wsVern));
+				Words_para0.Add(ras);
+				var bldr5 = Para0.Contents.GetIncBldr();
+				bldr5.AppendTsString(TsStringUtils.MakeString(
+					" " + Words_para0[20].Form.BestVernacularAlternative.Text +
+					" " + Words_para0[21].Form.BestVernacularAlternative.Text +
+					".", wsVern));
+				Para0.Contents = bldr5.GetString();
 				using (ParagraphParser pp = new ParagraphParser(Cache))
 				{
 					foreach (IStTxtPara para in StText.ParagraphsOS)
@@ -916,6 +927,21 @@ namespace SIL.LCModel.DomainServices
 			{
 				WordAnalysisOrGlossServices.CreateNewAnalysisWAG(setup.Words_para0[5]);
 				var wagLowercaseB = new AnalysisOccurrence(setup.Para0.SegmentsOS[1], 0);
+				var guessActual = setup.GuessServices.GetBestGuess(wagLowercaseB);
+				Assert.AreEqual(new NullWAG(), guessActual);
+			}
+		}
+
+		/// <summary>
+		/// if a wordform is mixed case, don't look for lower case.
+		/// </summary>
+		[Test]
+		public void ExpectedAnalysisGuess_ForSentenceInitialMixedCase()
+		{
+			using (var setup = new AnalysisGuessBaseSetup(Cache))
+			{
+				WordAnalysisOrGlossServices.CreateNewAnalysisWAG(setup.Words_para0[21]); // ras
+				var wagLowercaseB = new AnalysisOccurrence(setup.Para0.SegmentsOS[5], 0); // rAs
 				var guessActual = setup.GuessServices.GetBestGuess(wagLowercaseB);
 				Assert.AreEqual(new NullWAG(), guessActual);
 			}


### PR DESCRIPTION
A06-Kurdish uses A to represent a separate character from a.  But the icu locale thinks that A is the capital of a.  This means that the analysis guesser guesses analyses based on ras for rAs.  One easy way to fix this would be to change the A to U+0391 GREEK CAPITAL LETTER ALPHA, but the data is from outside the project.  An alternative is to only try lowercase analyses if the first letter of the wordform is uppercase.  This will still guess ras for RAs, but getting it to guess rAs instead would require a lot more work since there are several places in FieldWorks where it is assumed that you use ToLower to lowercase words.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/liblcm/326)
<!-- Reviewable:end -->
