### PR TITLE
Fix LT-22121: Analyze guesser should not guess ras for rAs

### DIFF
--- a/src/SIL.LCModel/DomainServices/AnalysisGuessServices.cs
+++ b/src/SIL.LCModel/DomainServices/AnalysisGuessServices.cs
@@ -385,11 +385,11 @@ namespace SIL.LCModel.DomainServices
 			}
 			if (originalCaseWf == form)
 				originalCaseWf = null;
-			if (!GuessTable.ContainsKey(form))
-			{
-				// Fill in GuessTable.
-				GuessTable[form] = GetContextCounts(form);
-			}
+
+			// Get context counts.
+			FillGuessTable(form);
+			FillGuessTable(originalCaseWf);
+			FillGuessTable(lowercaseWf);
 			contextCounts = GuessTable[form];
 			if (HasContextCounts(originalCaseWf) || HasContextCounts(lowercaseWf))
 			{
@@ -404,15 +404,20 @@ namespace SIL.LCModel.DomainServices
 			return contextCounts;
 		}
 
+		private void FillGuessTable(IAnalysis form)
+		{
+			if (form == null) return;
+			if (!GuessTable.ContainsKey(form))
+			{
+				// Fill in GuessTable.
+				GuessTable[form] = GetContextCounts(form);
+			}
+		}
+
 		private bool HasContextCounts(IWfiWordform wordform)
 		{
 			if (wordform == null)
 				return false;
-			if (!GuessTable.ContainsKey(wordform))
-			{
-				// Fill in GuessTable.
-				GuessTable[wordform] = GetContextCounts(wordform);
-			}
 			return GuessTable[wordform].wordform.Count > 0;
 		}
 

--- a/tests/SIL.LCModel.Tests/DomainServices/AnalysisGuessServicesTests.cs
+++ b/tests/SIL.LCModel.Tests/DomainServices/AnalysisGuessServicesTests.cs
@@ -181,6 +181,22 @@ namespace SIL.LCModel.DomainServices
 					" " + Words_para0[21].Form.BestVernacularAlternative.Text +
 					".", wsVern));
 				Para0.Contents = bldr5.GetString();
+				/* RAs */
+				IWfiWordform RAs = wfFactory.Create(TsStringUtils.MakeString("RAs", wsVern));
+				Words_para0.Add(RAs);
+				var bldr6 = Para0.Contents.GetIncBldr();
+				bldr6.AppendTsString(TsStringUtils.MakeString(
+					" " + Words_para0[22].Form.BestVernacularAlternative.Text +
+					".", wsVern));
+				Para0.Contents = bldr6.GetString();
+				/* RAS */
+				IWfiWordform RAS = wfFactory.Create(TsStringUtils.MakeString("RAS", wsVern));
+				Words_para0.Add(RAS);
+				var bldr7 = Para0.Contents.GetIncBldr();
+				bldr7.AppendTsString(TsStringUtils.MakeString(
+					" " + Words_para0[23].Form.BestVernacularAlternative.Text +
+					".", wsVern));
+				Para0.Contents = bldr7.GetString();
 				using (ParagraphParser pp = new ParagraphParser(Cache))
 				{
 					foreach (IStTxtPara para in StText.ParagraphsOS)
@@ -940,16 +956,16 @@ namespace SIL.LCModel.DomainServices
 		{
 			using (var setup = new AnalysisGuessBaseSetup(Cache))
 			{
-				var wagMixedCaseB = new AnalysisOccurrence(setup.Para0.SegmentsOS[5], 0); // rAs
+				var rAsOccurrence = new AnalysisOccurrence(setup.Para0.SegmentsOS[5], 0);
 
 				// Don't guess lowercase even if it exists.
 				IWfiAnalysis ras = WordAnalysisOrGlossServices.CreateNewAnalysisWAG(setup.Words_para0[21]);
-				var guessActual = setup.GuessServices.GetBestGuess(wagMixedCaseB);
+				var guessActual = setup.GuessServices.GetBestGuess(rAsOccurrence);
 				Assert.AreEqual(new NullWAG(), guessActual);
 
 				// Guess lowercase if the user has selected it.
-				wagMixedCaseB.Analysis = ras.Wordform;
-				guessActual = setup.GuessServices.GetBestGuess(wagMixedCaseB);
+				rAsOccurrence.Analysis = ras.Wordform;
+				guessActual = setup.GuessServices.GetBestGuess(rAsOccurrence);
 				Assert.AreEqual(ras, guessActual);
 			}
 		}
@@ -958,17 +974,49 @@ namespace SIL.LCModel.DomainServices
 		/// Test mixed case examples.
 		/// </summary>
 		[Test]
-		public void ExpectedAnalysisGuess_ForSentenceInitialMixedCaseWithUserLowercase()
+		public void ExpectedAnalysisGuess_ForSentenceInitialTitleMixedCase()
 		{
 			using (var setup = new AnalysisGuessBaseSetup(Cache))
 			{
-				var wagMixedCaseB = new AnalysisOccurrence(setup.Para0.SegmentsOS[5], 0); // rAs
+				var RAsOccurrence = new AnalysisOccurrence(setup.Para0.SegmentsOS[6], 0);
 
-				// Guess mixed case if it exists even if the user selects lowercase.
+				// Don't guess lowercase even if it exists.
 				IWfiAnalysis rAs = WordAnalysisOrGlossServices.CreateNewAnalysisWAG(setup.Words_para0[20]);
-				wagMixedCaseB.Analysis = setup.Words_para0[21];
-				var guessActual = setup.GuessServices.GetBestGuess(wagMixedCaseB);
+				var guessActual = setup.GuessServices.GetBestGuess(RAsOccurrence);
 				Assert.AreEqual(rAs, guessActual);
+			}
+		}
+
+		/// <summary>
+		/// Test mixed case examples.
+		/// </summary>
+		[Test]
+		public void ExpectedAnalysisGuess_ForSentenceInitialMixedCaseWithUnrelatedWordform()
+		{
+			using (var setup = new AnalysisGuessBaseSetup(Cache))
+			{
+				var rAsOccurrence = new AnalysisOccurrence(setup.Para0.SegmentsOS[5], 0);
+
+				// Guess mixed case if it exists even if the wordform is unrelated.
+				IWfiAnalysis rAs = WordAnalysisOrGlossServices.CreateNewAnalysisWAG(setup.Words_para0[20]);
+				rAsOccurrence.Analysis = setup.Words_para0[21]; // ras
+				var guessActual = setup.GuessServices.GetBestGuess(rAsOccurrence);
+				Assert.AreEqual(rAs, guessActual);
+			}
+		}
+
+		/// <summary>
+		/// Test all upper case.
+		/// </summary>
+		[Test]
+		public void ExpectedAnalysisGuess_ForAllUpperCase()
+		{
+			using (var setup = new AnalysisGuessBaseSetup(Cache))
+			{
+				var RASOccurrence = new AnalysisOccurrence(setup.Para0.SegmentsOS[7], 0);
+				IWfiAnalysis ras = WordAnalysisOrGlossServices.CreateNewAnalysisWAG(setup.Words_para0[21]);
+				var guessActual = setup.GuessServices.GetBestGuess(RASOccurrence);
+				Assert.AreEqual(ras, guessActual);
 			}
 		}
 

--- a/tests/SIL.LCModel.Tests/DomainServices/AnalysisGuessServicesTests.cs
+++ b/tests/SIL.LCModel.Tests/DomainServices/AnalysisGuessServicesTests.cs
@@ -170,6 +170,17 @@ namespace SIL.LCModel.DomainServices
 					" " + Words_para0[4].Form.BestVernacularAlternative.Text +
 					".", wsVern));
 				Para0.Contents = bldr4.GetString();
+				/* rAs ras */
+				IWfiWordform rAs = wfFactory.Create(TsStringUtils.MakeString("rAs", wsVern));
+				Words_para0.Add(rAs);
+				IWfiWordform ras = wfFactory.Create(TsStringUtils.MakeString("ras", wsVern));
+				Words_para0.Add(ras);
+				var bldr5 = Para0.Contents.GetIncBldr();
+				bldr5.AppendTsString(TsStringUtils.MakeString(
+					" " + Words_para0[20].Form.BestVernacularAlternative.Text +
+					" " + Words_para0[21].Form.BestVernacularAlternative.Text +
+					".", wsVern));
+				Para0.Contents = bldr5.GetString();
 				using (ParagraphParser pp = new ParagraphParser(Cache))
 				{
 					foreach (IStTxtPara para in StText.ParagraphsOS)
@@ -916,6 +927,21 @@ namespace SIL.LCModel.DomainServices
 			{
 				WordAnalysisOrGlossServices.CreateNewAnalysisWAG(setup.Words_para0[5]);
 				var wagLowercaseB = new AnalysisOccurrence(setup.Para0.SegmentsOS[1], 0);
+				var guessActual = setup.GuessServices.GetBestGuess(wagLowercaseB);
+				Assert.AreEqual(new NullWAG(), guessActual);
+			}
+		}
+
+		/// <summary>
+		/// if a wordform is mixed case, don't look for lower case.
+		/// </summary>
+		[Test]
+		public void ExpectedAnalysisGuess_ForSentenceInitialMixedCase()
+		{
+			using (var setup = new AnalysisGuessBaseSetup(Cache))
+			{
+				WordAnalysisOrGlossServices.CreateNewAnalysisWAG(setup.Words_para0[21]); // ras
+				var wagLowercaseB = new AnalysisOccurrence(setup.Para0.SegmentsOS[5], 0); // rAs
 				var guessActual = setup.GuessServices.GetBestGuess(wagLowercaseB);
 				Assert.AreEqual(new NullWAG(), guessActual);
 			}

--- a/tests/SIL.LCModel.Tests/DomainServices/AnalysisGuessServicesTests.cs
+++ b/tests/SIL.LCModel.Tests/DomainServices/AnalysisGuessServicesTests.cs
@@ -933,17 +933,42 @@ namespace SIL.LCModel.DomainServices
 		}
 
 		/// <summary>
-		/// if a wordform is mixed case, don't look for lower case.
+		/// Test mixed case examples.
 		/// </summary>
 		[Test]
 		public void ExpectedAnalysisGuess_ForSentenceInitialMixedCase()
 		{
 			using (var setup = new AnalysisGuessBaseSetup(Cache))
 			{
-				WordAnalysisOrGlossServices.CreateNewAnalysisWAG(setup.Words_para0[21]); // ras
-				var wagLowercaseB = new AnalysisOccurrence(setup.Para0.SegmentsOS[5], 0); // rAs
-				var guessActual = setup.GuessServices.GetBestGuess(wagLowercaseB);
+				var wagMixedCaseB = new AnalysisOccurrence(setup.Para0.SegmentsOS[5], 0); // rAs
+
+				// Don't guess lowercase even if it exists.
+				IWfiAnalysis ras = WordAnalysisOrGlossServices.CreateNewAnalysisWAG(setup.Words_para0[21]);
+				var guessActual = setup.GuessServices.GetBestGuess(wagMixedCaseB);
 				Assert.AreEqual(new NullWAG(), guessActual);
+
+				// Guess lowercase if the user has selected it.
+				wagMixedCaseB.Analysis = ras.Wordform;
+				guessActual = setup.GuessServices.GetBestGuess(wagMixedCaseB);
+				Assert.AreEqual(ras, guessActual);
+			}
+		}
+
+		/// <summary>
+		/// Test mixed case examples.
+		/// </summary>
+		[Test]
+		public void ExpectedAnalysisGuess_ForSentenceInitialMixedCaseWithUserLowercase()
+		{
+			using (var setup = new AnalysisGuessBaseSetup(Cache))
+			{
+				var wagMixedCaseB = new AnalysisOccurrence(setup.Para0.SegmentsOS[5], 0); // rAs
+
+				// Guess mixed case if it exists even if the user selects lowercase.
+				IWfiAnalysis rAs = WordAnalysisOrGlossServices.CreateNewAnalysisWAG(setup.Words_para0[20]);
+				wagMixedCaseB.Analysis = setup.Words_para0[21];
+				var guessActual = setup.GuessServices.GetBestGuess(wagMixedCaseB);
+				Assert.AreEqual(rAs, guessActual);
 			}
 		}
 


### PR DESCRIPTION
This fixes https://jira.sil.org/browse/LT-22121.  In order to handle cases where the occurrence was rAs but the wordform was ras, I changed the code to look up the wordform, the occurrence form, and the occurrence form with the first letter lowercased.  These are usually all the same, but in rare cases they can all be different if the user chooses a wordform that isn't the occurrence form or an initial lowercase form of the occurrence form.  This needed a lot of changes to the code.  This should probably be saved for release/9.3.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/liblcm/327)
<!-- Reviewable:end -->
