### PR TITLE
Fix LT-21945: Different modes for parsing vs. glossing

### DIFF
--- a/src/SIL.LCModel/DomainServices/AnalysisGuessServices.cs
+++ b/src/SIL.LCModel/DomainServices/AnalysisGuessServices.cs
@@ -29,11 +29,21 @@ namespace SIL.LCModel.DomainServices
 		///
 		/// </summary>
 		/// <param name="cache"></param>
-		public AnalysisGuessServices(LcmCache cache)
+		public AnalysisGuessServices(LcmCache cache) : this(cache, false)
+		{
+		}
+
+		/// <summary>
+		///
+		/// </summary>
+		/// <param name="cache"></param>
+		/// <param name="prioritizeParser">whether parser approval should be prioritized over human approval</param>
+		public AnalysisGuessServices(LcmCache cache, bool prioritizeParser)
 		{
 			Cache = cache;
 			m_emptyWAG = new EmptyWAG();
 			m_nullWAG = new NullWAG();
+			PrioritizeParser = prioritizeParser;
 		}
 
 		/// <summary>
@@ -56,6 +66,8 @@ namespace SIL.LCModel.DomainServices
 		}
 
 		public AnalysisOccurrence IgnoreOccurrence { get; set; }
+
+		public bool PrioritizeParser { get; set; }
 
 		LcmCache Cache { get; set; }
 
@@ -644,6 +656,21 @@ namespace SIL.LCModel.DomainServices
 		/// </summary>
 		private int ComparePriorityCounts(IAnalysis a1, IAnalysis a2, AnalysisOccurrence occurrence, ContextCount contextCount)
 		{
+			if (PrioritizeParser)
+			{
+				// Sort by parser approval.
+				IWfiAnalysis wfi1 = a1 as IWfiAnalysis;
+				IWfiAnalysis wfi2 = a2 as IWfiAnalysis;
+				if (wfi1 != null && wfi2 != null)
+				{
+					int p1 = IsParserApproved(wfi1) ? 3 : IsParserDisapproved(wfi1) ? 1 : 2;
+					int p2 = IsParserApproved(wfi2) ? 3 : IsParserDisapproved(wfi2) ? 1 : 2;
+					if (p1 < p2)
+						return 1;
+					if (p1 > p2)
+						return -1;
+				}
+			}
 			// Compare contexted counts.
 			if (occurrence != null)
 			{

--- a/tests/SIL.LCModel.Tests/DomainServices/AnalysisGuessServicesTests.cs
+++ b/tests/SIL.LCModel.Tests/DomainServices/AnalysisGuessServicesTests.cs
@@ -61,12 +61,12 @@ namespace SIL.LCModel.DomainServices
 
 			LcmCache Cache { get; set; }
 
-			internal AnalysisGuessBaseSetup(LcmCache cache) : this()
+			internal AnalysisGuessBaseSetup(LcmCache cache, bool prioritizeParser = false) : this()
 			{
 				Cache = cache;
 				UserAgent = Cache.LanguageProject.DefaultUserAgent;
 				ParserAgent = Cache.LangProject.DefaultParserAgent;
-				GuessServices = new AnalysisGuessServices(Cache);
+				GuessServices = new AnalysisGuessServices(Cache, prioritizeParser);
 				EntryFactory = Cache.ServiceLocator.GetInstance<ILexEntryFactory>();
 				DoDataSetup();
 			}
@@ -1248,6 +1248,22 @@ namespace SIL.LCModel.DomainServices
 				setup.UserAgent.SetEvaluation(newWagHumanApproves.Analysis, Opinions.approves);
 				var guessActual = setup.GuessServices.GetBestGuess(setup.Words_para0[1]);
 				Assert.AreEqual(newWagHumanApproves.Analysis, guessActual);
+			}
+		}
+
+		/// <summary>
+		/// </summary>
+		[Test]
+		public void ExpectedGuess_PreferParserApprovedAnalysisOverUserApprovedAnalysis()
+		{
+			using (var setup = new AnalysisGuessBaseSetup(Cache, true))
+			{
+				var newWagParserApproves = WordAnalysisOrGlossServices.CreateNewAnalysisWAG(setup.Words_para0[1]);
+				var newWagHumanApproves = WordAnalysisOrGlossServices.CreateNewAnalysisWAG(setup.Words_para0[1]);
+				setup.ParserAgent.SetEvaluation(newWagParserApproves.Analysis, Opinions.approves);
+				setup.UserAgent.SetEvaluation(newWagHumanApproves.Analysis, Opinions.approves);
+				var guessActual = setup.GuessServices.GetBestGuess(setup.Words_para0[1]);
+				Assert.AreEqual(newWagParserApproves.Analysis, guessActual);
 			}
 		}
 


### PR DESCRIPTION
This adds a PrioritizeParser parameter to AnalysisGuessServices to support an interlinear mode where parser approval is more important than human approval.