### PR TITLE
Fix LT-826: overtly order affixes in a template slot

### DIFF
--- a/src/SIL.LCModel/DomainImpl/OverridesLing_MoClasses.cs
+++ b/src/SIL.LCModel/DomainImpl/OverridesLing_MoClasses.cs
@@ -2749,9 +2749,11 @@ namespace SIL.LCModel.DomainImpl
 			get
 			{
 				((ICmObjectRepositoryInternal)Services.ObjectRepository).EnsureCompleteIncomingRefsFrom(MoInflAffMsaTags.kflidSlots);
-				return from msa in m_incomingRefs
+				var affixes = from msa in m_incomingRefs
 						where msa.Source is IMoInflAffMsa && ((IMoInflAffMsa) msa.Source).SlotsRC.Contains(this)
 						select (IMoInflAffMsa) msa.Source;
+				int flid = Cache.DomainDataByFlid.MetaDataCache.GetFieldId2(this.ClassID, "Affixes", true);
+				return VirtualOrderingServices.GetOrderedValue(this, flid, affixes);
 			}
 		}
 


### PR DESCRIPTION
This is the liblcm part of the fix for https://jira.sil.org/browse/LT-826.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/liblcm/331)
<!-- Reviewable:end -->
