### PR TITLE
Fix LT-21976: Merge Create dates when merging entries

### DIFF
--- a/src/SIL.LCModel/Application/ApplicationServices/XmlImportData.cs
+++ b/src/SIL.LCModel/Application/ApplicationServices/XmlImportData.cs
@@ -165,6 +165,7 @@ namespace SIL.LCModel.Application.ApplicationServices
 		private ReferenceTracker m_rglinks = new ReferenceTracker();
 		private TextWriter m_wrtrLog;
 		private bool m_createLinks;
+		private DateTime m_importDate = DateTime.Now;
 
 
 		/// ------------------------------------------------------------------------------------
@@ -470,6 +471,7 @@ namespace SIL.LCModel.Application.ApplicationServices
 			ILexSense[] rgls = leOld.SensesOS.ToArray();
 			for (int i = 0; i < rgls.Length; ++i)
 				leNew.SensesOS.Add(rgls[i]);
+			MergeDates(leOld, leNew);
 			MergeEntryRefs(leOld, leNew);
 			CopyCustomFieldData(leOld, leNew);
 
@@ -477,6 +479,23 @@ namespace SIL.LCModel.Application.ApplicationServices
 			string id;
 			if (m_mapGuidId.TryGetValue(leOld.Guid, out id))
 				m_mapIdGuid[id] = leNew.Guid;
+		}
+
+		/// Use the newest date between the two dates, as long as it is different from the importDate
+		private void MergeDates(ILexEntry leOld, ILexEntry leNew)
+		{
+			if (leOld.DateCreated == m_importDate)
+			{
+				return;
+			}
+			if (leNew.DateCreated == m_importDate)
+			{
+				leNew.DateCreated = leOld.DateCreated;
+			}
+			else if (leOld.DateCreated > leNew.DateCreated)
+			{
+				leNew.DateCreated = leOld.DateCreated;
+			}
 		}
 
 		private void MergeEntryRefs(ILexEntry leOld, ILexEntry leNew)
@@ -1089,6 +1108,7 @@ namespace SIL.LCModel.Application.ApplicationServices
 								if (m_factLexEntry == null)
 									m_factLexEntry = m_cache.ServiceLocator.GetInstance<ILexEntryFactory>();
 								cmo = m_factLexEntry.Create();
+								((LexEntry)cmo).DateCreated = m_importDate;
 								m_nHomograph = 0;
 								break;
 							case TextTags.kClassId:

--- a/tests/SIL.LCModel.Tests/Application/ApplicationServices/XmlImportDataTests.cs
+++ b/tests/SIL.LCModel.Tests/Application/ApplicationServices/XmlImportDataTests.cs
@@ -479,7 +479,6 @@ namespace SIL.LCModel.Application.ApplicationServices
 		/// </summary>
 		///--------------------------------------------------------------------------------------
 		[Test]
-		//[Ignore("This needs to be rewritten so that imported files are in resources.")]
 		public void ImportData3()
 		{
 			XmlImportData xid = new XmlImportData(m_cache, true);
@@ -1380,6 +1379,38 @@ namespace SIL.LCModel.Application.ApplicationServices
 			}
 		}
 
+		///
+		[Test]
+		public void MergeCreatedDateWorks()
+		{
+			var xid = new XmlImportData(m_cache, false);
+			var createdDate = "2011-09-14 12:00:00.000";
+			using (var reader = new StringReader("<LexDb xmlns:msxsl=\"urn:schemas-microsoft-com:xslt\" xmlns:user=\"urn:my-scripts\">" +
+				 "<Entries><LexEntry><LexemeForm><MoStemAllomorph><MorphType><Link ws=\"en\" name=\"stem\" /></MorphType>" +
+				 "<Form><AUni ws=\"cub\">ãcʉriojomecacʉ</AUni></Form></MoStemAllomorph></LexemeForm><DateCreated>" +
+				 $"<Time val=\"{createdDate}\" /></DateCreated><DialectLabels><Link ws=\"en\" abbr=\"C\" name=\"C\" />" +
+				 "</DialectLabels><EntryRefs><LexEntryRef><ComponentLexemes><Link ws=\"cub\" entry=\"ãcʉriojʉmecacʉ\" />" +
+				 "</ComponentLexemes></LexEntryRef></EntryRefs></LexEntry><LexEntry id=\"IID0E3\"><LexemeForm><MoStemAllomorph>" +
+				 "<MorphType><Link ws=\"en\" name=\"stem\" /></MorphType><Form><AUni ws=\"cub\">ãcʉriojʉmecacʉ</AUni></Form>" +
+				 "</MoStemAllomorph></LexemeForm><DateCreated><Time val=\"2011-09-14 12:00:00.000\" /></DateCreated><DialectLabels>" +
+				 "<Link ws=\"en\" abbr=\"Q\" name=\"Q\" /><Link ws=\"en\" abbr=\"V\" name=\"V\" /></DialectLabels>" +
+				 "<MorphoSyntaxAnalyses><MoStemMsa id=\"MSA1000\"><PartOfSpeech><Link ws=\"en\" abbr=\"s.\" /></PartOfSpeech>" +
+				 "</MoStemMsa></MorphoSyntaxAnalyses><Senses><LexSense><Definition><AStr ws=\"en\">" +
+				 "<Run ws=\"en\">tree species cf jocʉcʉ</Run></AStr></Definition><MorphoSyntaxAnalysis><Link target=\"MSA1000\" />" +
+				 "</MorphoSyntaxAnalysis></LexSense></Senses></LexEntry><LexEntry><LexemeForm><MoStemAllomorph><MorphType>" +
+				 "<Link ws=\"en\" name=\"stem\" /></MorphType><Form><AUni ws=\"cub\">ãcʉriojomecacʉ</AUni></Form></MoStemAllomorph>" +
+				 "</LexemeForm><EntryRefs><LexEntryRef><VariantEntryTypes><Link ws=\"es\" name=\"Variante\" /></VariantEntryTypes>" +
+				 "<ComponentLexemes><Link target=\"IID0E3\" /></ComponentLexemes></LexEntryRef></EntryRefs></LexEntry></Entries></LexDb>"))
+			{
+				StringBuilder sbLog = new StringBuilder();
+				xid.ImportData(reader, new StringWriter(sbLog), null);
+				var entries = m_cache.LangProject.LexDbOA.Entries.ToArray();
+				Assert.That(entries.Length, Is.EqualTo(2), "The lexicon should have 2 entries.");
+				Assert.That(entries[0].DateCreated, Is.EqualTo(entries[1].DateCreated));
+				Assert.That(entries[0].DateCreated, Is.EqualTo(DateTime.Parse(createdDate)),
+					"The DateCreated of the entries should match the import data.");
+			}
+		}
 		///--------------------------------------------------------------------------------------
 		/// <summary>
 		/// Tests the method ImportData() on sequence lexical relations.


### PR DESCRIPTION
* Store the date at the start of the import and use it in entry creation. We need to have a consistent date recorded to determine if we read a date from the xml data or not.
* Add a function to return the newest date that was actually read from the xml data.