### PR TITLE
Fix LT-22241: User Disapproved analyses should be included

### DIFF
--- a/src/SIL.LCModel/DomainServices/AnalysisGuessServices.cs
+++ b/src/SIL.LCModel/DomainServices/AnalysisGuessServices.cs
@@ -234,9 +234,12 @@ namespace SIL.LCModel.DomainServices
 			return result;
 		}
 
-		bool IsNotDisapproved(IWfiAnalysis wa)
+		bool IncludeAnalysis(IWfiAnalysis wa)
 		{
+			// Exclude human-disapproved analyses unless we are in Parsing Dev mode.
 			ICmAgentEvaluation cae = null;
+			if (PrioritizeParser)
+				return true;
 			foreach (var ae in wa.EvaluationsRC)
 				if (((ICmAgent)ae.Owner).Human)
 					cae = ae;
@@ -512,7 +515,7 @@ namespace SIL.LCModel.DomainServices
 			// Include analyses that may not have been selected.
 			foreach (IWfiAnalysis analysis in wordform.AnalysesOC)
 			{
-				if (IsNotDisapproved(analysis))
+				if (IncludeAnalysis(analysis))
 				{
 					// Human takes priority over parser which takes priority over computer.
 					// Approved takes priority over disapproved.
@@ -538,7 +541,7 @@ namespace SIL.LCModel.DomainServices
 		{
 			var counts = new Dictionary<IAnalysis, Dictionary<IAnalysis, PriorityCount>>();
 			var segs = new HashSet<ISegment>();
-			if (!IsNotDisapproved(analysis))
+			if (!IncludeAnalysis(analysis))
 				return counts;
 			foreach (ISegment seg in analysis.Wordform.OccurrencesInTexts)
 			{


### PR DESCRIPTION
This fixes https://jira.sil.org/browse/LT-22241.  Human disapproved analyses should not be excluded in Parsing development mode.  I renamed IsNotDisapproved to IncludeAnalysis for clarity.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/liblcm/335)
<!-- Reviewable:end -->
