### PR TITLE
Add SpecificItemAndFieldName() to ISenseOrEntry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 
+- [SIL.LCModel] Add SpecificItemAndFieldName() to ISenseOrEntry
 - [SIL.LCModel] Added a parameter to GetBestGuess() and TryGetBestGuess() to do lowercase matching regardless of the occurrence index
 - [SIL.LCModel] Add GetCaptionOrHeadword() to CmPicture
 - [SIL.LCModel] `LCModelStrings.NotSure` to allow clients to know if a grammatical category is the placeholder

--- a/src/SIL.LCModel/DomainImpl/OverridesLing_Lex.cs
+++ b/src/SIL.LCModel/DomainImpl/OverridesLing_Lex.cs
@@ -10082,21 +10082,13 @@ namespace SIL.LCModel.DomainImpl
 		{
 			specificObject = Item;
 			specificFieldName = fieldName;
-			if (fieldName == "HeadWordRef")
+			if (fieldName == "HeadWordRef" && Item is ILexSense)
 			{
-				var sense = Item as ILexSense;
-				if (sense != null)
-				{
-					specificFieldName = "MLOwnerOutlineName";
-				}
+				specificFieldName = "MLOwnerOutlineName";
 			}
-			else if (fieldName == "EntryRefsOS")
+			else if (fieldName == "EntryRefsOS" && Item is ILexSense sense)
 			{
-				var sense = Item as ILexSense;
-				if (sense != null)
-				{
-					specificObject = sense.Entry;
-				}
+				specificObject = sense.Entry;
 			}
 		}
 	}

--- a/src/SIL.LCModel/InterfaceAdditions.cs
+++ b/src/SIL.LCModel/InterfaceAdditions.cs
@@ -6006,6 +6006,5 @@ namespace SIL.LCModel
 		/// <param name="specificFieldName">The specific field name that will need to be used to get
 		/// the value from the specificItem.</param>
 		void SpecificItemAndFieldName(string fieldName, out ICmObject specificItem, out string specificFieldName);
-
 	}
 }


### PR DESCRIPTION
Added to support a fix for LT-22124 in Fieldworks.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/liblcm/337)
<!-- Reviewable:end -->
