### PR TITLE
Fix LT-22251: Phonological Features field missing labels

### DIFF
--- a/src/SIL.LCModel/DomainImpl/OverridesCellar.cs
+++ b/src/SIL.LCModel/DomainImpl/OverridesCellar.cs
@@ -4014,12 +4014,11 @@ namespace SIL.LCModel.DomainImpl
 
 		/// <summary>
 		/// Provide a "Name" for this.
-		/// Use short name to satisfy LT-22133.
 		/// </summary>
 		/// <returns></returns>
 		public override string ToString()
 		{
-			return ShortName;
+			return LongName;
 		}
 
 		/// <summary>


### PR DESCRIPTION
I fixed https://jira.sil.org/browse/LT-22251 by undoing LT-22133.  I will have to fix LT-22133 in FieldWorks.