### PR TITLE
Fix LT-22155: Merge entry/sense losing some custom fields

### DIFF
--- a/src/SIL.LCModel/DomainImpl/CmObject.cs
+++ b/src/SIL.LCModel/DomainImpl/CmObject.cs
@@ -833,9 +833,16 @@ namespace SIL.LCModel.DomainImpl
 							myCurrentValue = new MultiStringAccessor(this, flid);
 							srcCurrentValue = new MultiStringAccessor(objSrc, flid);
 							break;
-						case (int)CellarPropertyType.MultiUnicode:
-							myCurrentValue = new MultiUnicodeAccessor(this, flid);
-							srcCurrentValue = new MultiUnicodeAccessor(objSrc, flid);
+						case (int)CellarPropertyType.OwningAtomic:
+						case (int)CellarPropertyType.ReferenceAtomic:
+							int myHvo = m_cache.DomainDataByFlid.get_ObjectProp(Hvo, flid);
+							int srcHvo = m_cache.DomainDataByFlid.get_ObjectProp(objSrc.Hvo, flid);
+							myCurrentValue = m_cache.GetAtomicPropObject(myHvo);
+							srcCurrentValue = m_cache.GetAtomicPropObject(srcHvo);
+							break;
+						default:
+							myCurrentValue = this.GetCustomPropertyForSDA(flid);
+							srcCurrentValue = ((CmObject)objSrc).GetCustomPropertyForSDA(flid);
 							break;
 					}
 				}


### PR DESCRIPTION
This fixes https://jira.sil.org/browse/LT-22155.  The code for custom fields was missing a bunch of types.  I added a "default" case that should catch everything, but I couldn't test all of the possibilities, just the ones in LT-22155.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/liblcm/340)
<!-- Reviewable:end -->
