### PR TITLE
Fix false-positive ArrayPtr dispose warning

### DIFF
--- a/src/SIL.LCModel.Utils/ArrayPtr.cs
+++ b/src/SIL.LCModel.Utils/ArrayPtr.cs
@@ -111,7 +111,6 @@ namespace SIL.LCModel.Utils
 		/// ------------------------------------------------------------------------------------
 		~ArrayPtr()
 		{
-			//if (this != s_null) // TODO (Hasso) 2016.11: is this the only place this ugly hack is needed?
 			Dispose(false);
 			// The base class finalizer is called automatically.
 		}
@@ -150,8 +149,8 @@ namespace SIL.LCModel.Utils
 		/// ------------------------------------------------------------------------------------
 		protected virtual void Dispose(bool disposing)
 		{
-			// If you're getting this line it means that you forgot to call Dispose().
-			Debug.WriteLineIf(!disposing,// && this != s_Null, // TODO (Hasso) 2016.11: is this the only place this ugly hack is needed?
+			// Only warn for finalized instances that actually own allocated memory.
+			Debug.WriteLineIf(!disposing && m_ownMemory,
 				"****** Missing Dispose() call for " + GetType().Name + ". ****** ");
 
 			// Must not be run more than once.

--- a/src/SIL.LCModel.Utils/ArrayPtr.cs
+++ b/src/SIL.LCModel.Utils/ArrayPtr.cs
@@ -149,8 +149,9 @@ namespace SIL.LCModel.Utils
 		/// ------------------------------------------------------------------------------------
 		protected virtual void Dispose(bool disposing)
 		{
-			// Only warn for finalized instances that actually own allocated memory.
-			Debug.WriteLineIf(!disposing && m_ownMemory,
+			// Only warn for finalized instances that own an unmanaged buffer that was
+			// actually allocated by this ArrayPtr.
+			Debug.WriteLineIf(!disposing && m_ownMemory && m_ptr != IntPtr.Zero,
 				"****** Missing Dispose() call for " + GetType().Name + ". ****** ");
 
 			// Must not be run more than once.


### PR DESCRIPTION
## Summary
Suppress the ArrayPtr finalizer warning for non-owning wrappers such as ArrayPtr.Null while preserving the warning for managed-owned unmanaged buffers.

## Why
FieldWorks debug sessions were reporting a misleading "Missing Dispose() call for ArrayPtr" message at shutdown even when the finalized ArrayPtr instance did not own unmanaged memory.

## Validation
- Rebuilt the local liblcm net462 runtime overlay
- Verified the updated SIL.LCModel DLL and PDB files were copied into FieldWorks Output/Debug
- Confirmed the change is limited to ArrayPtr warning behavior

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/liblcm/370)
<!-- Reviewable:end -->
