### PR TITLE
Fix LT-21889: Add Find and Fix step for removing disowned children

### DIFF
--- a/src/SIL.LCModel.FixData/FwDataFixer.cs
+++ b/src/SIL.LCModel.FixData/FwDataFixer.cs
@@ -256,6 +256,11 @@ namespace SIL.LCModel.FixData
 							errorLogger(String.Format(Strings.ksRemovingObjectWithBadOwner, guidOwner, className, guid), true);
 							return false;
 						}
+						else
+						{
+							errorLogger(String.Format(Strings.ksRemovingDisownedObject, guidOwner, className, guid), true);
+							return false;
+						}
 					}
 				}
 				else if (storedOwner != Guid.Empty)

--- a/src/SIL.LCModel.FixData/Strings.Designer.cs
+++ b/src/SIL.LCModel.FixData/Strings.Designer.cs
@@ -259,6 +259,15 @@ namespace SIL.LCModel.FixData {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Removing disowned object (invalid ownerguid=&apos;{0}&apos;, class=&apos;{1}&apos;, guid=&apos;{2}&apos;)..
+        /// </summary>
+        public static string ksRemovingDisownedObject {
+            get {
+                return ResourceManager.GetString("ksRemovingDisownedObject", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Removing owner of empty sequence (guid=&apos;{0}&apos; class=&apos;{1}&apos;) from its owner (guid=&apos;{2}&apos;)..
         /// </summary>
         public static string ksRemovingOwnerOfEmptySequence {

--- a/src/SIL.LCModel.FixData/Strings.resx
+++ b/src/SIL.LCModel.FixData/Strings.resx
@@ -135,6 +135,9 @@
   <data name="ksRemovingObjectWithBadOwner" xml:space="preserve">
     <value>Removing object with nonexistent owner (invalid ownerguid='{0}', class='{1}', guid='{2}').</value>
   </data>
+  <data name="ksRemovingDisownedObject" xml:space="preserve">
+    <value>Removing disowned object (invalid ownerguid='{0}', class='{1}', guid='{2}').</value>
+  </data>
   <data name="ksAddingLinkToOwner" xml:space="preserve">
     <value>Adding ownerguid='{0}' (class='{1}', guid='{2}').</value>
   </data>

--- a/tests/SIL.LCModel.FixData.Tests/FwDataFixerTests.cs
+++ b/tests/SIL.LCModel.FixData.Tests/FwDataFixerTests.cs
@@ -442,6 +442,7 @@ namespace SIL.LCModel.FixData.Tests
 			var danglingMorphNoRepairGuid = "5752ed24-40e1-4282-9ba0-d82c89592432";
 			var danglingMorphNoRepairAfGuid = "1f568cae-b0f8-413d-84a6-41cbd90923e9";
 			var disownedOwnerGuid = "16827d7a-cf4e-45f8-aaa1-66cef5c2cc4d";
+			var disownedGuid = "1f568cae-b0f8-413d-84a6-41cbd90923e9";
 
 			// Verify initial state.
 			// We start out with morph bundles that have broken links.
@@ -481,7 +482,7 @@ namespace SIL.LCModel.FixData.Tests
 				"Error message is incorrect."); // MorphBundleFixer--ksRemovingDanglingMsa
 			Assert.That(_errors[8], Is.EqualTo("Removing dangling link to Form '" + danglingMsaGuid + "' for WfiMorphBundle '" + danglingMorphNoRepairGuid + "'."),
 				"Error message is incorrect."); // MorphBundleFixer--ksRemovingDanglingMorph
-			Assert.True(_errors[9].StartsWith("Removing disowned object (invalid ownerguid='" + disownedOwnerGuid),
+			Assert.True(_errors[9].StartsWith("Removing disowned object (invalid ownerguid='" + disownedOwnerGuid + "', class='WfiMorphBundle', guid='" + disownedGuid),
 				"Error message is incorrect."); // MorphBundleFixer--ksRemovingDanglingMorph
 			Assert.That(_errors[10], Is.EqualTo("Removing dangling link to Form '" + danglingMsaGuid + "' for WfiMorphBundle '" + danglingMorphNoRepairAfGuid + "'."),
 				"Error message is incorrect."); // MorphBundleFixer--ksRemovingDanglingMorph
@@ -501,6 +502,8 @@ namespace SIL.LCModel.FixData.Tests
 				"//rt[@class=\"WfiMorphBundle\" and @guid=\"" + danglingMorphNoRepairGuid + "\"]/Morph", 0);  // must remove Morph, not just child objsur
 			AssertThatXmlIn.File(Path.Combine(testPath, "BasicFixup.fwdata")).HasSpecifiedNumberOfMatchesForXpath(
 				"//rt[@class=\"WfiMorphBundle\" and @guid=\"" + danglingMorphNoRepairAfGuid + "\"]/Morph/objsur", 0);
+			AssertThatXmlIn.File(Path.Combine(testPath, "BasicFixup.fwdata")).HasSpecifiedNumberOfMatchesForXpath(
+				"//rt[@class=\"WfiMorphBundle\" and @guid=\"" + disownedGuid + "\"]/Morph/objsur", 0);
 		}
 
 		/// <summary>

--- a/tests/SIL.LCModel.FixData.Tests/FwDataFixerTests.cs
+++ b/tests/SIL.LCModel.FixData.Tests/FwDataFixerTests.cs
@@ -441,6 +441,7 @@ namespace SIL.LCModel.FixData.Tests
 			var danglingMorphGoodSenseGuid = "9665bf3b-2aab-4f7f-88a9-4ca738b75110";
 			var danglingMorphNoRepairGuid = "5752ed24-40e1-4282-9ba0-d82c89592432";
 			var danglingMorphNoRepairAfGuid = "1f568cae-b0f8-413d-84a6-41cbd90923e9";
+			var disownedOwnerGuid = "16827d7a-cf4e-45f8-aaa1-66cef5c2cc4d";
 
 			// Verify initial state.
 			// We start out with morph bundles that have broken links.
@@ -463,7 +464,7 @@ namespace SIL.LCModel.FixData.Tests
 				"//rt[@class=\"WfiMorphBundle\" and @guid=\"" + danglingMorphNoRepairAfGuid + "\"]/Morph/objsur[@guid=\"" + danglingMsaGuid + "\"]", 1);
 
 			// Check errors
-			Assert.AreEqual(10, _errors.Count, "Unexpected number of errors found.");
+			Assert.AreEqual(11, _errors.Count, "Unexpected number of errors found.");
 			Assert.True(_errors[0].StartsWith("Removing dangling link to '" + danglingMsaGuid + "' (class='LexEntry'"),
 				"Error message is incorrect."); // OriginalFixer--ksRemovingLinkToNonexistingObject
 			Assert.That(_errors[1], Is.EqualTo("Fixing link to MSA based on Sense MSA (class='WfiMorphBundle', guid='" + repairableBundleGuid + "')."),
@@ -480,7 +481,9 @@ namespace SIL.LCModel.FixData.Tests
 				"Error message is incorrect."); // MorphBundleFixer--ksRemovingDanglingMsa
 			Assert.That(_errors[8], Is.EqualTo("Removing dangling link to Form '" + danglingMsaGuid + "' for WfiMorphBundle '" + danglingMorphNoRepairGuid + "'."),
 				"Error message is incorrect."); // MorphBundleFixer--ksRemovingDanglingMorph
-			Assert.That(_errors[9], Is.EqualTo("Removing dangling link to Form '" + danglingMsaGuid + "' for WfiMorphBundle '" + danglingMorphNoRepairAfGuid + "'."),
+			Assert.True(_errors[9].StartsWith("Removing disowned object (invalid ownerguid='" + disownedOwnerGuid),
+				"Error message is incorrect."); // MorphBundleFixer--ksRemovingDanglingMorph
+			Assert.That(_errors[10], Is.EqualTo("Removing dangling link to Form '" + danglingMsaGuid + "' for WfiMorphBundle '" + danglingMorphNoRepairAfGuid + "'."),
 				"Error message is incorrect."); // MorphBundleFixer--ksRemovingDanglingMorph
 
 			// Check file repair

--- a/tests/SIL.LCModel.FixData.Tests/TestData/DeletedMsaRefBySenseAndBundle/Test.fwdata
+++ b/tests/SIL.LCModel.FixData.Tests/TestData/DeletedMsaRefBySenseAndBundle/Test.fwdata
@@ -20,12 +20,12 @@
 
 	<rt class="WfiWordform" guid ="31c5a1c0-270e-4edf-9406-4ed445bd27c4">
 		<Analyses>
-			<objsur guid="16827d7a-cf4e-45f8-aaa1-66cef5c2cc4d" type="o"/>
+			<objsur guid="16827d7a-cf4e-45f8-aaa1-66cef5c2cc4d" t="o"/>
 		</Analyses>
 	</rt>
 	<rt class="WfiAnalysis" guid ="16827d7a-cf4e-45f8-aaa1-66cef5c2cc4d" ownerguid="31c5a1c0-270e-4edf-9406-4ed445bd27c4">
 		<MorphBundles>
-			<objsur guid="10f3db1e-33db-4d9d-9a06-e0a8e1ed8a92" type="o"/>
+			<objsur guid="10f3db1e-33db-4d9d-9a06-e0a8e1ed8a92" t="o"/>
 		</MorphBundles>
 	</rt>
 	<rt class="WfiMorphBundle" guid ="10f3db1e-33db-4d9d-9a06-e0a8e1ed8a92" ownerguid="16827d7a-cf4e-45f8-aaa1-66cef5c2cc4d">

--- a/tests/SIL.LCModel.FixData.Tests/TestData/MorphBundleProblems/Test.fwdata
+++ b/tests/SIL.LCModel.FixData.Tests/TestData/MorphBundleProblems/Test.fwdata
@@ -25,12 +25,17 @@
 
 	<rt class="WfiWordform" guid ="31c5a1c0-270e-4edf-9406-4ed445bd27c4">
 		<Analyses>
-			<objsur guid="16827d7a-cf4e-45f8-aaa1-66cef5c2cc4d" type="o"/>
+			<objsur guid="16827d7a-cf4e-45f8-aaa1-66cef5c2cc4d" t="o"/>
 		</Analyses>
 	</rt>
 	<rt class="WfiAnalysis" guid ="16827d7a-cf4e-45f8-aaa1-66cef5c2cc4d" ownerguid="31c5a1c0-270e-4edf-9406-4ed445bd27c4">
 		<MorphBundles>
-			<objsur guid="10f3db1e-33db-4d9d-9a06-e0a8e1ed8a92" type="o"/>
+			<objsur guid="10f3db1e-33db-4d9d-9a06-e0a8e1ed8a92" t="o"/>
+			<objsur guid="d70b57bc-ecfe-4e32-a590-f2852bce69fc" t="o"/>
+			<objsur guid="e4396e8e-b7d2-43ba-93bd-104cf2011aaf" t="o"/>
+			<objsur guid="cb941dc9-6f6e-44b2-97f2-07854e164b4e" t="o"/>
+			<objsur guid="9665bf3b-2aab-4f7f-88a9-4ca738b75110" t="o"/>
+			<objsur guid="5752ed24-40e1-4282-9ba0-d82c89592432" t="o"/>
 		</MorphBundles>
 	</rt>
 	<rt class="WfiMorphBundle" guid ="10f3db1e-33db-4d9d-9a06-e0a8e1ed8a92" ownerguid="16827d7a-cf4e-45f8-aaa1-66cef5c2cc4d">


### PR DESCRIPTION
This fixes https://jira.sil.org/browse/LT-21889.  If the owner and stored owner don't match and the owner exists and the stored owner doesn't exist then the node has been disowned.  This revealed some problems with the unit tests (type="o" instead of t="o").

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/liblcm/372)
<!-- Reviewable:end -->
