### PR TITLE
Fix LcmMetaDataCache race condition on static Flid counter

### DIFF
--- a/src/SIL.LCModel/Infrastructure/Impl/LcmMetaDataCache.cs
+++ b/src/SIL.LCModel/Infrastructure/Impl/LcmMetaDataCache.cs
@@ -69,25 +69,29 @@ namespace SIL.LCModel.Infrastructure.Impl
 		#endregion Data Members for IFwMetaDataCache Support
 
 		#region Construction
+		private static readonly object s_constructorLock = new object();
 
 		/// <summary>
 		/// Constructor.
 		/// </summary>
 		internal LcmMetaDataCache()
 		{
-			m_initialized = false;
+			lock (s_constructorLock)
+			{
+				m_initialized = false;
 
-			// Reset static counters for attrs.
-			VirtualPropertyAttribute.ResetFlidCounter();
-			FieldDescription.ClearDataAbout();
+				// Reset static counters for attrs.
+				VirtualPropertyAttribute.ResetFlidCounter();
+				FieldDescription.ClearDataAbout();
 
-			var cmObjectTypesBaseFirst = CmObjectTypesBaseFirst();
+				var cmObjectTypesBaseFirst = CmObjectTypesBaseFirst();
 
-			CmObjectSurrogate.InitializeConstructors(cmObjectTypesBaseFirst);
+				CmObjectSurrogate.InitializeConstructors(cmObjectTypesBaseFirst);
 
-			InitializeMetaDataCache(cmObjectTypesBaseFirst);
+				InitializeMetaDataCache(cmObjectTypesBaseFirst);
 
-			m_initialized = true;
+				m_initialized = true;
+			}
 		}
 
 		/// <summary/>


### PR DESCRIPTION
Somewhat similar to a previous race condition I fixed in https://github.com/sillsdev/liblcm/pull/371.

This constructor resets a static "Flid counter", so when multiple caches are initialized in parallel our tests can stumble over duplicate Flid's in the same cache, which I _think_ resulted in this exception:

> ---- SIL.LCModel.LcmInvalidFieldException : Fieldname 'Affixes' does not exist. Consider using a decorator or review the fieldname for typos.
>   Stack Trace:
>      at FwDataMiniLcmBridge.Api.FwDataMiniLcmApi.CreateEntry(Entry entry, CreateEntryOptions options) in D:\a\languageforge-lexbox\languageforge-lexbox\backend\FwLite\FwDataMiniLcmBridge\Api\FwDataMiniLcmApi.cs:line 1009
>    at FwLiteProjectSync.Tests.EntrySyncTestsBase.CanSyncRandomEntries(Nullable`1 roundTripApiType) in D:\a\languageforge-lexbox\languageforge-lexbox\backend\FwLite\FwLiteProjectSync.Tests\EntrySyncTests.cs:line 194
> --- End of stack trace from previous location ---
> ----- Inner Stack Trace -----
>    at SIL.LCModel.Infrastructure.Impl.LcmMetaDataCache.GetFieldId2(Int32 clid, String fieldName, Boolean includeBaseClasses)
>    at SIL.LCModel.DomainServices.VirtualOrderingServices.CheckParentAndGetFieldName(ICmObject parent, Int32 flid)
>    at SIL.LCModel.DomainServices.VirtualOrderingServices.GetOrderedValue(ICmObject parent, Int32 flid, IEnumerable`1 unmodifiedSeq)
>    at SIL.LCModel.DomainServices.VirtualOrderingServices.GetOrderedValue[T](ICmObject parent, Int32 flid, IEnumerable`1 unmodifiedSeq)
>    at SIL.LCModel.DomainImpl.LexEntry.get_VisibleComplexFormBackRefs()
>    at SIL.LCModel.DomainImpl.LexEntryRef.UpdateComplexFormEntryBackRefs(ICmObject thingAddedOrRemoved, Boolean fAdded)
>    at SIL.LCModel.DomainImpl.LexEntryRef.AddObjectSideEffectsInternal(AddObjectEventArgs e)
>    at SIL.LCModel.DomainImpl.CmObject.SIL.LCModel.ICmObjectInternal.AddObjectSideEffects(AddObjectEventArgs e)
>    at SIL.LCModel.DomainImpl.LcmList`1.AddObject(AddObjectEventArgs args)
>    at SIL.LCModel.DomainImpl.LcmReferenceSequence`1.AddObject(AddObjectEventArgs args)
>    at SIL.LCModel.DomainImpl.LcmList`1.Add(T obj)
>    at SIL.LCModel.DomainImpl.LexEntry.AddComponent(ICmObject other)
>    at FwDataMiniLcmBridge.Api.FwDataMiniLcmApi.InsertComplexFormComponent(ILexEntry lexComplexForm, ICmObject lexComponent, BetweenPosition`1 between) in D:\a\languageforge-lexbox\languageforge-lexbox\backend\FwLite\FwDataMiniLcmBridge\Api\FwDataMiniLcmApi.cs:line 1112
>    at FwDataMiniLcmBridge.Api.FwDataMiniLcmApi.AddComplexFormComponent(ILexEntry lexComplexForm, ComplexFormComponent component, BetweenPosition`1 between) in D:\a\languageforge-lexbox\languageforge-lexbox\backend\FwLite\FwDataMiniLcmBridge\Api\FwDataMiniLcmApi.cs:line 1096
>    at FwDataMiniLcmBridge.Api.FwDataMiniLcmApi.<>c__DisplayClass125_0.<CreateEntry>b__0() in D:\a\languageforge-lexbox\languageforge-lexbox\backend\FwLite\FwDataMiniLcmBridge\Api\FwDataMiniLcmApi.cs:line 996
>    at SIL.LCModel.Infrastructure.UndoableUnitOfWorkHelper.Do(String undoText, String redoText, IActionHandler actionHandler, Action task)
>  ...

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/liblcm/373)
<!-- Reviewable:end -->
