### PR TITLE
git-ignore new C# DevKit VS Code extension files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,5 @@ src/SIL.LCModel/IOC/Generated*.cs
 src/SIL.LCModel.Core/FwKernelTlb.idl
 src/SIL.LCModel.Core/FwKernelTlb.json
 icu4c.readme.txt
+
+*.lscache


### PR DESCRIPTION
Adds `*.lscache` to `.gitignore` for files generated by the C# DevKit VS Code extension.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/liblcm/374)
<!-- Reviewable:end -->
