### PR TITLE
Use DateCreated as homograph tie-breaker

### DIFF
--- a/src/SIL.LCModel/DomainImpl/OverridesLing_Lex.cs
+++ b/src/SIL.LCModel/DomainImpl/OverridesLing_Lex.cs
@@ -417,8 +417,13 @@ namespace SIL.LCModel.DomainImpl
 			{
 				// Should we notify the user that we're doing this helpful renumbering for him?
 				// We do our best to keep them in the same order.
+				// Tie-break on DateCreated then Guid so the result is deterministic and reasonable.
 				int n = 1;
-				foreach (ILexEntry le in rgHomographs.OrderBy(h => h.HomographNumber).ToList())
+				foreach (ILexEntry le in rgHomographs
+					.OrderBy(h => h.HomographNumber)
+					.ThenBy(h => h.DateCreated)
+					.ThenBy(h => h.Guid)
+					.ToList())
 				{
 					if (le.HomographNumber != n)
 						le.HomographNumber = n;

--- a/src/SIL.LCModel/DomainImpl/OverridesLing_Lex.cs
+++ b/src/SIL.LCModel/DomainImpl/OverridesLing_Lex.cs
@@ -2044,6 +2044,20 @@ namespace SIL.LCModel.DomainImpl
 			return result;
 		}
 
+		/// <summary>See <see cref="ILexEntry.CorrectHomographNumbers"/>.</summary>
+		public bool CorrectHomographNumbers()
+		{
+			if (HomographFormKey == Strings.ksQuestions)
+			{
+				if (HomographNumber == 0) return true;
+				HomographNumber = 0;
+				return false;
+			}
+			var homographs = Services.GetInstance<ILexEntryRepository>()
+				.CollectHomographs(HomographFormKey, PrimaryMorphType);
+			return LexDb.CorrectHomographNumbers(homographs);
+		}
+
 		partial void LexemeFormOASideEffects(IMoForm oldObjValue, IMoForm newObjValue)
 		{
 			string oldVal = oldObjValue == null ? "" : oldObjValue.Form.VernacularDefaultWritingSystem.Text;

--- a/src/SIL.LCModel/DomainImpl/OverridesLing_Lex.cs
+++ b/src/SIL.LCModel/DomainImpl/OverridesLing_Lex.cs
@@ -2044,20 +2044,6 @@ namespace SIL.LCModel.DomainImpl
 			return result;
 		}
 
-		/// <summary>See <see cref="ILexEntry.CorrectHomographNumbers"/>.</summary>
-		public bool CorrectHomographNumbers()
-		{
-			if (HomographFormKey == Strings.ksQuestions)
-			{
-				if (HomographNumber == 0) return true;
-				HomographNumber = 0;
-				return false;
-			}
-			var homographs = Services.GetInstance<ILexEntryRepository>()
-				.CollectHomographs(HomographFormKey, PrimaryMorphType);
-			return LexDb.CorrectHomographNumbers(homographs);
-		}
-
 		partial void LexemeFormOASideEffects(IMoForm oldObjValue, IMoForm newObjValue)
 		{
 			string oldVal = oldObjValue == null ? "" : oldObjValue.Form.VernacularDefaultWritingSystem.Text;

--- a/src/SIL.LCModel/Infrastructure/Impl/RepositoryAdditions.cs
+++ b/src/SIL.LCModel/Infrastructure/Impl/RepositoryAdditions.cs
@@ -1366,6 +1366,25 @@ namespace SIL.LCModel.Infrastructure.Impl
 		}
 
 		/// <summary>
+		/// Validate and, if needed, correct homograph numbers for the set <paramref name="entry"/>
+		/// participates in. Zeros the entry's HomographNumber if form is blank (so callers
+		/// don't need to special-case that).
+		/// Caller should create the unit of work.
+		/// </summary>
+		/// <returns>true if no change was needed, false if anything was renumbered.</returns>
+		public bool CorrectHomographNumbers(ILexEntry entry)
+		{
+			var form = entry.HomographFormKey;
+			if (form == Strings.ksQuestions)
+			{
+				if (entry.HomographNumber == 0) return true;
+				entry.HomographNumber = 0;
+				return false;
+			}
+			return LexDb.CorrectHomographNumbers(CollectHomographs(form, entry.PrimaryMorphType));
+		}
+
+		/// <summary>
 		/// Main method to collect all the homographs of the given form from the given list of entries.
 		/// Set hvo to 0 to collect absolutely every matching homograph.
 		/// </summary>

--- a/src/SIL.LCModel/InterfaceAdditions.cs
+++ b/src/SIL.LCModel/InterfaceAdditions.cs
@@ -1288,14 +1288,6 @@ namespace SIL.LCModel
 			get;
 		}
 
-		/// <summary>
-		/// Validate and, if needed, correct homograph numbers for this entry's homograph set.
-		/// Caller should create the unit of work.
-		/// Primarily wraps <see cref="ILexEntry.CorrectHomographNumbers"/>.
-		/// </summary>
-		/// <returns>true if homographs were already valid, false if they had to be renumbered.</returns>
-		bool CorrectHomographNumbers();
-
 		/// <summary/>
 		ITsString HeadWord
 		{

--- a/src/SIL.LCModel/InterfaceAdditions.cs
+++ b/src/SIL.LCModel/InterfaceAdditions.cs
@@ -1288,6 +1288,14 @@ namespace SIL.LCModel
 			get;
 		}
 
+		/// <summary>
+		/// Validate and, if needed, correct homograph numbers for this entry's homograph set.
+		/// Caller should create the unit of work.
+		/// Primarily wraps <see cref="ILexEntry.CorrectHomographNumbers"/>.
+		/// </summary>
+		/// <returns>true if homographs were already valid, false if they had to be renumbered.</returns>
+		bool CorrectHomographNumbers();
+
 		/// <summary/>
 		ITsString HeadWord
 		{

--- a/src/SIL.LCModel/RepositoryInterfaceAdditions.cs
+++ b/src/SIL.LCModel/RepositoryInterfaceAdditions.cs
@@ -427,6 +427,15 @@ namespace SIL.LCModel
 		List<ILexEntry> CollectHomographs(string sForm, IMoMorphType morphType);
 
 		/// <summary>
+		/// Validate and, if needed, correct homograph numbers for the set <paramref name="entry"/>
+		/// participates in. Zeros the entry's HomographNumber if form is blank (so callers
+		/// don't need to special-case that).
+		/// Caller should create the unit of work.
+		/// </summary>
+		/// <returns>true if no change was needed, false if anything was renumbered.</returns>
+		bool CorrectHomographNumbers(ILexEntry entry);
+
+		/// <summary>
 		/// Maps the specified morph type onto a canonical ordering that should be used in comparing two
 		/// entries to see whether they are homographs.
 		/// </summary>

--- a/tests/SIL.LCModel.Tests/DomainImpl/LingTests.cs
+++ b/tests/SIL.LCModel.Tests/DomainImpl/LingTests.cs
@@ -268,13 +268,13 @@ namespace SIL.LCModel.DomainImpl
 		}
 
 		/// <summary>
-		/// Exercises the entry-level wrapper
-		/// (Algorithm behaviour is covered by HomographValidationWorks.)
+		/// Algorithm behaviour is covered by HomographValidationWorks.
+		/// This just exercises the wrapper.
 		/// </summary>
 		[Test]
-		public void CorrectHomographNumbers_OnEntry_RenumbersInvalidSet()
+		public void CorrectHomographNumbers_RenumbersInvalidSet()
 		{
-			const string sLexForm = "entryCorrectHnTest";
+			const string sLexForm = "repoCorrectHnTest";
 			var e1 = MakeEntry(sLexForm);
 			var e2 = MakeEntry(sLexForm);
 			var e3 = MakeEntry(sLexForm);
@@ -283,23 +283,25 @@ namespace SIL.LCModel.DomainImpl
 			e2.HomographNumber = 2;
 			e3.HomographNumber = 0;
 
-			Assert.IsFalse(e1.CorrectHomographNumbers(), "Invalid set should be renumbered.");
+			var repo = Cache.ServiceLocator.GetInstance<ILexEntryRepository>();
+			Assert.IsFalse(repo.CorrectHomographNumbers(e1), "Invalid set should be renumbered.");
 			CollectionAssert.AreEquivalent(new[] { 1, 2, 3 },
 				new[] { e1.HomographNumber, e2.HomographNumber, e3.HomographNumber });
-			Assert.IsTrue(e1.CorrectHomographNumbers(), "Already-valid set: no change.");
+			Assert.IsTrue(repo.CorrectHomographNumbers(e1), "Already-valid set: no change.");
 		}
 
 		/// <summary>
 		/// Empty-form branch added on top of LexDb.CorrectHomographNumbers.
 		/// </summary>
 		[Test]
-		public void CorrectHomographNumbers_OnEntryWithEmptyForm_ForcesZero()
+		public void CorrectHomographNumbers_EmptyForm_ForcesZero()
 		{
 			var entry = MakeEntry("");
 			Assert.AreEqual(Strings.ksQuestions, entry.HomographFormKey);
 			entry.HomographNumber = 7;
 
-			Assert.IsFalse(entry.CorrectHomographNumbers());
+			var repo = Cache.ServiceLocator.GetInstance<ILexEntryRepository>();
+			Assert.IsFalse(repo.CorrectHomographNumbers(entry));
 			Assert.AreEqual(0, entry.HomographNumber);
 		}
 

--- a/tests/SIL.LCModel.Tests/DomainImpl/LingTests.cs
+++ b/tests/SIL.LCModel.Tests/DomainImpl/LingTests.cs
@@ -267,6 +267,42 @@ namespace SIL.LCModel.DomainImpl
 			}
 		}
 
+		/// <summary>
+		/// Exercises the entry-level wrapper
+		/// (Algorithm behaviour is covered by HomographValidationWorks.)
+		/// </summary>
+		[Test]
+		public void CorrectHomographNumbers_OnEntry_RenumbersInvalidSet()
+		{
+			const string sLexForm = "entryCorrectHnTest";
+			var e1 = MakeEntry(sLexForm);
+			var e2 = MakeEntry(sLexForm);
+			var e3 = MakeEntry(sLexForm);
+
+			e1.HomographNumber = 2;
+			e2.HomographNumber = 2;
+			e3.HomographNumber = 0;
+
+			Assert.IsFalse(e1.CorrectHomographNumbers(), "Invalid set should be renumbered.");
+			CollectionAssert.AreEquivalent(new[] { 1, 2, 3 },
+				new[] { e1.HomographNumber, e2.HomographNumber, e3.HomographNumber });
+			Assert.IsTrue(e1.CorrectHomographNumbers(), "Already-valid set: no change.");
+		}
+
+		/// <summary>
+		/// Empty-form branch added on top of LexDb.CorrectHomographNumbers.
+		/// </summary>
+		[Test]
+		public void CorrectHomographNumbers_OnEntryWithEmptyForm_ForcesZero()
+		{
+			var entry = MakeEntry("");
+			Assert.AreEqual(Strings.ksQuestions, entry.HomographFormKey);
+			entry.HomographNumber = 7;
+
+			Assert.IsFalse(entry.CorrectHomographNumbers());
+			Assert.AreEqual(0, entry.HomographNumber);
+		}
+
 		private ILexEntry MakeEntry(string sLexForm)
 		{
 			var lme = Cache.ServiceLocator.GetInstance<ILexEntryFactory>().Create();

--- a/tests/SIL.LCModel.Tests/DomainImpl/LingTests.cs
+++ b/tests/SIL.LCModel.Tests/DomainImpl/LingTests.cs
@@ -268,6 +268,36 @@ namespace SIL.LCModel.DomainImpl
 		}
 
 		/// <summary>
+		/// When a full renumber is needed, ties on HomographNumber are broken by
+		/// DateCreated (then Guid) so that the outcome is entirely deterministic.
+		/// </summary>
+		[Test]
+		public void CorrectHomographNumbers_FullRenumber_TieBreaksByDateCreated()
+		{
+			const string sLexForm = "tieBreakTest";
+			var e1 = MakeEntry(sLexForm);
+			var e2 = MakeEntry(sLexForm);
+			var e3 = MakeEntry(sLexForm);
+
+			e1.HomographNumber = 5;
+			e2.HomographNumber = 5;
+			e3.HomographNumber = 5;
+
+			// Reverse natural creation order so DateCreated differs from insertion order.
+			var baseTime = new DateTime(2020, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+			e3.DateCreated = baseTime;
+			e2.DateCreated = baseTime.AddMinutes(1);
+			e1.DateCreated = baseTime.AddMinutes(2);
+
+			var fOk = LexDb.CorrectHomographNumbers(new List<ILexEntry> { e1, e2, e3 });
+
+			Assert.IsFalse(fOk, "CorrectHomographNumbers had to renumber homographs");
+			Assert.AreEqual(1, e3.HomographNumber, "oldest DateCreated wins HN=1");
+			Assert.AreEqual(2, e2.HomographNumber);
+			Assert.AreEqual(3, e1.HomographNumber, "newest DateCreated gets HN=3");
+		}
+
+		/// <summary>
 		/// Algorithm behaviour is covered by HomographValidationWorks.
 		/// This just exercises the wrapper.
 		/// </summary>


### PR DESCRIPTION
Extends the reassignment of homographs to `OrderBy(HomographNumber).ThenBy(DateCreated).ThenBy(Guid)`, so that homograph re-ordering is easier to reason about.

The previous tie-break relied on `OrderBy`'s stable sort over the homograph cache's dictionary insertion order, which is theoretically deterministic, but not intuitive.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/liblcm/376)
<!-- Reviewable:end -->
