### PR TITLE
LT-14056: Crash with Undo then Redo deleted Lexical Relations

### DIFF
--- a/src/SIL.LCModel/DomainImpl/CmObject.cs
+++ b/src/SIL.LCModel/DomainImpl/CmObject.cs
@@ -2629,11 +2629,8 @@ namespace SIL.LCModel.DomainImpl
 		{
 			// Add a null cache guard. (See LT-14056: when using redo button to delete a lexical relation that was "undeleted" via undo,
 			// it tries to restore refs after deleting the object and crashes b/c Cache is null.)
-			if (Cache == null)
-			{
-				Debug.Fail("Restoring incoming refs on outgoing refs for an object already deleted");
-				return;
-			}
+			if (Cache == null) { return; }
+
 			var mdc = Cache.ServiceLocator.GetInstance<IFwMetaDataCacheManaged>();
 			foreach (var flid in mdc.GetFields(ClassID, true, (int)CellarPropertyTypeFilter.AllReference))
 			{

--- a/src/SIL.LCModel/DomainImpl/CmObject.cs
+++ b/src/SIL.LCModel/DomainImpl/CmObject.cs
@@ -2627,6 +2627,13 @@ namespace SIL.LCModel.DomainImpl
 		/// </summary>
 		protected virtual void RestoreIncomingRefsOnOutgoingRefsInternal()
 		{
+			// Add a null cache guard. (See LT-14056: when using redo button to delete a lexical relation that was "undeleted" via undo,
+			// it tries to restore refs after deleting the object and crashes b/c Cache is null.)
+			if (Cache == null)
+			{
+				Debug.Fail("Restoring incoming refs on outgoing refs for an object already deleted");
+				return;
+			}
 			var mdc = Cache.ServiceLocator.GetInstance<IFwMetaDataCacheManaged>();
 			foreach (var flid in mdc.GetFields(ClassID, true, (int)CellarPropertyTypeFilter.AllReference))
 			{

--- a/src/SIL.LCModel/DomainImpl/Vectors.cs
+++ b/src/SIL.LCModel/DomainImpl/Vectors.cs
@@ -1779,6 +1779,13 @@ namespace SIL.LCModel.DomainImpl
 		/// </summary>
 		public override void RestoreAfterUndo()
 		{
+			// Add a null cache guard. (See LT-14056: when using redo button to delete a lexical relation that was "undeleted" via undo,
+			// it tries to restore refs after deleting the object and crashes b/c Cache is null.)
+			if (MainObject.Cache == null)
+			{
+				Debug.Fail("Restoring incoming refs on outgoing refs for an object already deleted");
+				return;
+			}
 			// First we must make sure all the objects are real. This is very like a loop over
 			// FluffUpObjectIfNeeded; but do NOT use that, because it will add extra incoming refs
 			// for anything that isn't already fluffed.

--- a/src/SIL.LCModel/DomainImpl/Vectors.cs
+++ b/src/SIL.LCModel/DomainImpl/Vectors.cs
@@ -1781,11 +1781,8 @@ namespace SIL.LCModel.DomainImpl
 		{
 			// Add a null cache guard. (See LT-14056: when using redo button to delete a lexical relation that was "undeleted" via undo,
 			// it tries to restore refs after deleting the object and crashes b/c Cache is null.)
-			if (MainObject.Cache == null)
-			{
-				Debug.Fail("Restoring incoming refs on outgoing refs for an object already deleted");
-				return;
-			}
+			if (MainObject.Cache == null) { return; }
+
 			// First we must make sure all the objects are real. This is very like a loop over
 			// FluffUpObjectIfNeeded; but do NOT use that, because it will add extra incoming refs
 			// for anything that isn't already fluffed.


### PR DESCRIPTION
Add null cache guards. The redo is deleting a lexical relation that was just "undeleted" via undo. Tries to restore refs when the object has already been deleted.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/liblcm/383)
<!-- Reviewable:end -->
