### PR TITLE
Replace System.Web with System.Net.WebUtility in data migration

### DIFF
--- a/src/SIL.LCModel/DomainServices/DataMigration/DataMigration7000037.cs
+++ b/src/SIL.LCModel/DomainServices/DataMigration/DataMigration7000037.cs
@@ -7,8 +7,8 @@
 
 using System;
 using System.IO;
+using System.Net;
 using System.Text;
-using System.Web;
 using System.Xml.Linq;
 using System.Xml.XPath;
 using SIL.LCModel.Utils;
@@ -66,7 +66,7 @@ namespace SIL.LCModel.DomainServices.DataMigration
 					value = kFwUrlPrefix.Substring(0, 1) + value;
 				if (!value.StartsWith(kFwUrlPrefix))
 					continue;
-				string query = HttpUtility.UrlDecode(value.Substring(kFwUrlPrefix.Length));
+				string query = WebUtility.UrlDecode(value.Substring(kFwUrlPrefix.Length));
 				string[] rgsProps = query.Split(new char[] {'&'}, StringSplitOptions.RemoveEmptyEntries);
 				string database = null;
 				int idxDatabase = -1;
@@ -130,7 +130,7 @@ namespace SIL.LCModel.DomainServices.DataMigration
 				if (!fChange)
 					continue;
 
-				value = kFwUrlPrefix + HttpUtility.UrlEncode(string.Join("&", rgsProps));
+				value = kFwUrlPrefix + WebUtility.UrlEncode(string.Join("&", rgsProps));
 				if (attrLink.Value != value)
 				{
 					attrLink.Value = value;

--- a/src/SIL.LCModel/SIL.LCModel.csproj
+++ b/src/SIL.LCModel/SIL.LCModel.csproj
@@ -108,10 +108,6 @@
     <Clean Include="@(GeneratedFiles)" />
   </ItemGroup>
 
-  <ItemGroup>
-    <Reference Include="System.Web" />
-  </ItemGroup>
-
   <Target Name="GenerateModel" Inputs="MasterLCModel.xml" Outputs="@(GeneratedFiles)" BeforeTargets="BeforeCompile">
     <!-- Call the LcmGenerate task from SIL.LCModel.Build.Tasks in a separate msbuild process,
          so it doesn't lock the SIL.LCModel.Build.Tasks.dll in VS. -->

--- a/tests/SIL.LCModel.Tests/DomainServices/DataMigration/DataMigration7000037Tests.cs
+++ b/tests/SIL.LCModel.Tests/DomainServices/DataMigration/DataMigration7000037Tests.cs
@@ -4,7 +4,7 @@
 
 using System;
 using System.Collections.Generic;
-using System.Web;
+using System.Net;
 using System.Xml.Linq;
 using System.Xml.XPath;
 using NUnit.Framework;
@@ -122,7 +122,7 @@ namespace SIL.LCModel.DomainServices.DataMigration
 			}
 			Assert.IsTrue(externalLink.StartsWith(FwUrlPrefix),
 				"silfw link should start with " + FwUrlPrefix);
-			string query = HttpUtility.UrlDecode(externalLink.Substring(FwUrlPrefix.Length));
+			string query = WebUtility.UrlDecode(externalLink.Substring(FwUrlPrefix.Length));
 			string[] rgsProps = query.Split(new char[] { '&' }, StringSplitOptions.RemoveEmptyEntries);
 			string tool = null;
 			Guid guid = Guid.Empty;

--- a/tests/SIL.LCModel.Tests/DomainServices/DataMigration/DataMigration7000040Tests.cs
+++ b/tests/SIL.LCModel.Tests/DomainServices/DataMigration/DataMigration7000040Tests.cs
@@ -5,9 +5,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Web;
 using System.Xml.Linq;
-using System.Xml.XPath;
 using NUnit.Framework;
 using SIL.LCModel.Utils;
 
@@ -23,8 +21,6 @@ namespace SIL.LCModel.DomainServices.DataMigration
 	[TestFixture]
 	public class DataMigration7000040Tests : DataMigrationTestsBase
 	{
-		private const string FwUrlPrefix = "silfw://localhost/link?";
-
 		///--------------------------------------------------------------------------------------
 		/// <summary>
 		///  Test the migration from version 7000039 to 7000040.
@@ -99,81 +95,6 @@ namespace SIL.LCModel.DomainServices.DataMigration
 			var objsur = osElements.ToArray()[index];
 			Assert.That(objsur.Attribute("guid").Value, Is.EqualTo(guid));
 			Assert.That(objsur.Attribute("t").Value, Is.EqualTo("r"));
-		}
-
-		int m_cLinks;
-		List<string> m_rgsOtherLinks = new List<string>();
-
-		private void CollectionNonSilfwLinks(IDomainObjectDTORepository dtoRepos)
-		{
-			foreach (var dto in dtoRepos.AllInstancesWithValidClasses())
-			{
-				string xml = dto.Xml;
-				Assert.IsTrue(xml.Contains("externalLink"), "Every object in the test has an externalLink");
-				var dtoXML = XElement.Parse(xml);
-				foreach (var run in dtoXML.XPathSelectElements("//Run"))
-				{
-					var externalLinkAttr = run.Attribute("externalLink");
-					if (externalLinkAttr != null)
-					{
-						string value = externalLinkAttr.Value;
-						if (value.StartsWith("http://") || value.StartsWith("libronixdls:"))
-							m_rgsOtherLinks.Add(value);
-						++m_cLinks;
-					}
-				}
-			}
-
-		}
-
-		private void CheckForValidLinkValue(string externalLink)
-		{
-			int idxColon = externalLink.IndexOf(':');
-			Assert.Greater(idxColon, 0, "links must have a colon to separate off the type of link");
-			string linkType = externalLink.Substring(0, idxColon);
-			switch (linkType)
-			{
-				case "http":
-				case "libronixdls":
-					Assert.IsTrue(m_rgsOtherLinks.Contains(externalLink),
-						"Migration should not affect http or libronix links");
-					return;
-				default:
-					Assert.AreEqual("silfw", linkType);
-					break;
-			}
-			Assert.IsTrue(externalLink.StartsWith(FwUrlPrefix),
-				"silfw link should start with " + FwUrlPrefix);
-			string query = HttpUtility.UrlDecode(externalLink.Substring(FwUrlPrefix.Length));
-			string[] rgsProps = query.Split(new char[] { '&' }, StringSplitOptions.RemoveEmptyEntries);
-			string tool = null;
-			Guid guid = Guid.Empty;
-			for (int i = 0; i < rgsProps.Length; ++i)
-			{
-				string[] propPair = rgsProps[i].Split('=');
-				switch (propPair[0])
-				{
-					case "app":
-						Assert.AreEqual("flex", propPair[1], "silfw link - app should equal \"flex\"");
-						break;
-					case "server":
-						Assert.That(propPair[1], Is.Null.Or.Empty, "silfw link - server should be empty");
-						break;
-					case "database":
-						Assert.AreEqual("this$", propPair[1], "silfw link - database should equal \"this$\"");
-						break;
-					case "tool":
-						tool = propPair[1];
-						break;
-					case "guid":
-						guid = new Guid(propPair[1]);
-						break;
-					default:
-						break;
-				}
-			}
-			Assert.That(tool, Is.Not.Null.And.Not.Empty, "silfw link - tool should have a value");
-			Assert.AreNotEqual(Guid.Empty, guid, "silfw link - guid should have a value");
 		}
 	}
 }

--- a/tests/SIL.LCModel.Tests/SIL.LCModel.Tests.csproj
+++ b/tests/SIL.LCModel.Tests/SIL.LCModel.Tests.csproj
@@ -24,10 +24,6 @@ This package provides unit tests for SIL.LCModel.</Description>
     <ProjectReference Include="..\SIL.LCModel.Core.Tests\SIL.LCModel.Core.Tests.csproj" />
   </ItemGroup>
 
-  <ItemGroup>
-    <Reference Include="System.Web" />
-  </ItemGroup>
-
   <Target Name="CollectRuntimeOutputs" BeforeTargets="_GetPackageFiles">
     <ItemGroup>
       <None Include="$(OutputPath)\**\$(PackageId).dll.config" Pack="true" PackagePath="lib" />


### PR DESCRIPTION
This allows us to remove our dependency on `System.Web.HttpUtility` which is designed for use on the server per https://learn.microsoft.com/en-us/dotnet/api/system.web.httputility?view=net-10.0#remarks 

for DataMigration7000040Tests.cs I removed the unused copy-pasted helpers that still referenced System.Web and were never called by the test.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/liblcm/384)
<!-- Reviewable:end -->
