### PR TITLE
Add net8.0 target to SIL.LCModel, Utils, and FixData

### DIFF
--- a/src/SIL.LCModel.FixData/SIL.LCModel.FixData.csproj
+++ b/src/SIL.LCModel.FixData/SIL.LCModel.FixData.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net462;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net462;net8.0</TargetFrameworks>
     <RootNamespace>SIL.LCModel.FixData</RootNamespace>
     <Description>The liblcm library is the core FieldWorks model for linguistic analyses of languages. Tools in this library provide the ability to store and interact with language and culture data, including anthropological, text corpus, and linguistics data.
 SIL.LCModel.FixData provides functionality to fix errors in a FieldWorks data XML file.</Description>

--- a/src/SIL.LCModel.Utils/SIL.LCModel.Utils.csproj
+++ b/src/SIL.LCModel.Utils/SIL.LCModel.Utils.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net462;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net462;net8.0</TargetFrameworks>
     <RootNamespace>SIL.LCModel.Utils</RootNamespace>
     <Description>The liblcm library is the core FieldWorks model for linguistic analyses of languages. Tools in this library provide the ability to store and interact with language and culture data, including anthropological, text corpus, and linguistics data.
 SIL.LCModel.Utils provides utility classes.</Description>
@@ -17,7 +17,7 @@ SIL.LCModel.Utils provides utility classes.</Description>
     <PackageReference Include="System.Configuration.ConfigurationManager" Version="6.0.0" />
     <PackageReference Include="System.Diagnostics.PerformanceCounter" Version="6.0.0" />
     <PackageReference Include="System.Management" Version="6.0.0" />
-    <Reference Include="System.Management" />
+    <Reference Include="System.Management" Condition="'$(TargetFramework)' == 'net462'" />
   </ItemGroup>
 
   <Target Name="CheckWinForms" BeforeTargets="CoreCompile">

--- a/src/SIL.LCModel/SIL.LCModel.csproj
+++ b/src/SIL.LCModel/SIL.LCModel.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net462;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net462;net8.0</TargetFrameworks>
     <RootNamespace>SIL.LCModel</RootNamespace>
     <Description>The liblcm library is the core FieldWorks model for linguistic analyses of languages. Tools in this library provide the ability to store and interact with language and culture data, including anthropological, text corpus, and linguistics data.
 	SIL.LCModel is the main library.</Description>


### PR DESCRIPTION
Not sure why we weren't targeting net8 on only core, but now we're targeting it on the other projects as well.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/liblcm/385)
<!-- Reviewable:end -->
