### PR TITLE
Fix LT-22351: load default font features in BaseStyleInfo.ProcessStyleRules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 
+- [SIL.LCModel] BaseStyleInfo now loads default font features (ktptFontVariations) from style rules, fixing font features set as style defaults being dropped on reload (LT-22351)
 - [SIL.LCModel] Deleting a duplicated phonological rule no longer deletes pooled feature constraints and environment contexts the original rule still references (LT-22575)
 - [SIL.LCModel] Fixed crash when bulk deleting entries involved in a lexical relation (LT-21598)
 - [SIL.LCModel.FixData] Find and Fix removes duplicate Targets from a LexReference (and deletes it if fewer than two distinct Targets remain) (LT-21598)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Fixed
 
 - [SIL.LCModel] BaseStyleInfo now loads default font features (ktptFontVariations) from style rules, fixing font features set as style defaults being dropped on reload (LT-22351)
+- [SIL.LCModel] BaseStyleInfo no longer clobbers ws-specific font overrides inherited from a based-on style with the default font info's merely-inherited values; only explicitly-set default properties are propagated to ws overrides (LT-22351)
 - [SIL.LCModel] Deleting a duplicated phonological rule no longer deletes pooled feature constraints and environment contexts the original rule still references (LT-22575)
 - [SIL.LCModel] Fixed crash when bulk deleting entries involved in a lexical relation (LT-21598)
 - [SIL.LCModel.FixData] Find and Fix removes duplicate Targets from a LexReference (and deletes it if fewer than two distinct Targets remain) (LT-21598)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - [SIL.LCModel] BaseStyleInfo now loads default font features (ktptFontVariations) from style rules, fixing font features set as style defaults being dropped on reload (LT-22351)
 - [SIL.LCModel] BaseStyleInfo no longer clobbers ws-specific font overrides inherited from a based-on style with the default font info's merely-inherited values; only explicitly-set default properties are propagated to ws overrides (LT-22351)
+- [SIL.LCModel] BulletInfo now decodes all properties of an encoded bullet font info instead of stopping at the first string property, fixing bullet font features (ktptFontVariations) being lost when a bullet font name was also set (LT-22351)
 - [SIL.LCModel] Deleting a duplicated phonological rule no longer deletes pooled feature constraints and environment contexts the original rule still references (LT-22575)
 - [SIL.LCModel] Fixed crash when bulk deleting entries involved in a lexical relation (LT-21598)
 - [SIL.LCModel.FixData] Find and Fix removes duplicate Targets from a LexReference (and deletes it if fewer than two distinct Targets remain) (LT-21598)

--- a/src/SIL.LCModel/DomainServices/BaseStyleInfo.cs
+++ b/src/SIL.LCModel/DomainServices/BaseStyleInfo.cs
@@ -935,6 +935,10 @@ namespace SIL.LCModel.DomainServices
 						m_defaultFontInfo.m_fontName.ExplicitValue = sProp;
 						break;
 
+					case (int)FwTextPropType.ktptFontVariations:
+						m_defaultFontInfo.m_features.ExplicitValue = sProp;
+						break;
+
 					case (int)FwTextPropType.ktptBulNumTxtBef:
 						{
 							m_bulletInfo.IsInherited = false;

--- a/src/SIL.LCModel/DomainServices/BaseStyleInfo.cs
+++ b/src/SIL.LCModel/DomainServices/BaseStyleInfo.cs
@@ -936,7 +936,7 @@ namespace SIL.LCModel.DomainServices
 						break;
 
 					case (int)FwTextPropType.ktptFontVariations:
-						m_defaultFontInfo.m_features.ExplicitValue = sProp;
+						SetFontStringProp(tpt, m_defaultFontInfo, sProp);
 						break;
 
 					case (int)FwTextPropType.ktptBulNumTxtBef:
@@ -1440,7 +1440,11 @@ namespace SIL.LCModel.DomainServices
 				fontInfoOverride.Value.InheritAllProperties(inheritPropsFrom);
 				if (m_defaultFontInfo.IsAnyExplicit)
 				{
-					fontInfoOverride.Value.InheritAllProperties(m_defaultFontInfo);
+					// Propagate only the explicitly-set default (style-level) properties into the
+					// override; the default's other values were merely inherited from the based-on
+					// style's default and must not clobber what was just inherited from the
+					// based-on style's ws override.
+					fontInfoOverride.Value.InheritExplicitProperties(m_defaultFontInfo);
 				}
 			}
 			m_rtl.InheritValue(basedOn.m_rtl);

--- a/src/SIL.LCModel/DomainServices/BulletInfo.cs
+++ b/src/SIL.LCModel/DomainServices/BulletInfo.cs
@@ -210,13 +210,13 @@ namespace SIL.LCModel.DomainServices
 					{
 						fontInfo.m_fontName.ExplicitValue = blob.Substring(i, iPropLim - i);
 						i += (iPropLim - i + 1);
-						break;
+						continue;
 					}
 					else if (tpt == FwTextPropType.ktptFontVariations)
 					{
 						fontInfo.m_features.ExplicitValue = blob.Substring(i, iPropLim - i);
 						i += (iPropLim - i + 1);
-						break;
+						continue;
 					}
 
 					int nVal = (int)blob[i] + (int)(blob[i + 1] << 16);

--- a/src/SIL.LCModel/DomainServices/FontInfo.cs
+++ b/src/SIL.LCModel/DomainServices/FontInfo.cs
@@ -273,5 +273,40 @@ namespace SIL.LCModel.DomainServices
 			m_offset.InheritValue(basedOnFontInfo.m_offset);
 			m_features.InheritValue(basedOnFontInfo.m_features);
 		}
+
+		/// ------------------------------------------------------------------------------------
+		/// <summary>
+		/// Inherit the values of only those properties that are explicitly set on the specified
+		/// font info, but don't force a change in the inherit value.
+		/// </summary>
+		/// <remarks>Explicitly set values on this font info will not be affected</remarks>
+		/// <param name="basedOnFontInfo">The font info from which to get the explicitly set
+		/// values.</param>
+		/// ------------------------------------------------------------------------------------
+		internal void InheritExplicitProperties(FontInfo basedOnFontInfo)
+		{
+			if (basedOnFontInfo.m_fontName.IsExplicit)
+				m_fontName.InheritValue(basedOnFontInfo.m_fontName);
+			if (basedOnFontInfo.m_fontSize.IsExplicit)
+				m_fontSize.InheritValue(basedOnFontInfo.m_fontSize);
+			if (basedOnFontInfo.m_fontColor.IsExplicit)
+				m_fontColor.InheritValue(basedOnFontInfo.m_fontColor);
+			if (basedOnFontInfo.m_backColor.IsExplicit)
+				m_backColor.InheritValue(basedOnFontInfo.m_backColor);
+			if (basedOnFontInfo.m_bold.IsExplicit)
+				m_bold.InheritValue(basedOnFontInfo.m_bold);
+			if (basedOnFontInfo.m_italic.IsExplicit)
+				m_italic.InheritValue(basedOnFontInfo.m_italic);
+			if (basedOnFontInfo.m_superSub.IsExplicit)
+				m_superSub.InheritValue(basedOnFontInfo.m_superSub);
+			if (basedOnFontInfo.m_underline.IsExplicit)
+				m_underline.InheritValue(basedOnFontInfo.m_underline);
+			if (basedOnFontInfo.m_underlineColor.IsExplicit)
+				m_underlineColor.InheritValue(basedOnFontInfo.m_underlineColor);
+			if (basedOnFontInfo.m_offset.IsExplicit)
+				m_offset.InheritValue(basedOnFontInfo.m_offset);
+			if (basedOnFontInfo.m_features.IsExplicit)
+				m_features.InheritValue(basedOnFontInfo.m_features);
+		}
 	}
 }

--- a/tests/SIL.LCModel.Tests/DomainServices/BaseStyleInfoTests.cs
+++ b/tests/SIL.LCModel.Tests/DomainServices/BaseStyleInfoTests.cs
@@ -300,6 +300,7 @@ namespace SIL.LCModel.DomainServices
 			Assert.IsTrue(fontInfo.m_features.IsExplicit,
 				"Default font features set on the style should be explicit, not inherited");
 			Assert.AreEqual("smcp=1,ss01=2", fontInfo.m_features.Value);
+			Assert.AreEqual("Arial", (string)fontInfo.m_fontName.Value);
 		}
 
 		/// <summary>
@@ -428,6 +429,66 @@ namespace SIL.LCModel.DomainServices
 				"The child entry in the StyleInfoCollection did not inherit the fontName properly");
 			Assert.AreEqual(childOverrides.FontName.Value, "Fontastic",
 				"The child entry in the StyleInfoCollection did not inherit the fontName properly");
+		}
+
+		/// <summary>
+		/// Tests that a child style whose only explicit style-level default is font features
+		/// (ktptFontVariations) does not clobber the ws-specific overrides it inherits from its
+		/// based-on style. The explicitly-set default properties should be propagated to the ws
+		/// overrides, but the default's merely-inherited values must not overwrite what was just
+		/// inherited from the based-on style's ws override. See LT-22351.
+		/// </summary>
+		[Test]
+		public void SetBasedOnStyleAndInheritValues_ExplicitDefaultFeaturesDoNotClobberWsOverride()
+		{
+			// Font family override for the parent style
+			byte[] buffer = new byte[] {
+				0xC1, 0x87, 0x8B, 0x3B, // WS for english (little endian)
+				0x09, 0x00, // FF length
+				(byte)'F', 0,
+				(byte)'o', 0,
+				(byte)'n', 0,
+				(byte)'t', 0,
+				(byte)'a', 0,
+				(byte)'s', 0,
+				(byte)'t', 0,
+				(byte)'i', 0,
+				(byte)'c', 0,
+
+				0x00, 0x00, // Count of int props
+			};
+
+			ITsPropsBldr props;
+
+			var mainTitleStyle = AddTestStyle("Title Main", ContextValues.Title,
+				StructureValues.Body, FunctionValues.Prose, false, Cache.LangProject.StylesOC);
+			var inheritFromMain = AddTestStyle("Inherit Title", ContextValues.Title, StructureValues.Body,
+				FunctionValues.Prose, false, Cache.LangProject.StylesOC);
+			inheritFromMain.BasedOnRA = mainTitleStyle;
+			// The parent style has a ws-specific font override and a different default font
+			props = mainTitleStyle.Rules.GetBldr();
+			props.SetStrPropValue((int)FwTextPropType.ktptFontFamily, "Times New Roman");
+			props.SetStrPropValue((int)FwTextPropType.ktptWsStyle, DummyStyleInfo.MakeStringFromBuffer(buffer));
+			mainTitleStyle.Rules = props.GetTextProps();
+			// The child style's only explicit style-level default is font features
+			props = inheritFromMain.Rules.GetBldr();
+			props.SetStrPropValue((int)FwTextPropType.ktptFontVariations, "smcp=1");
+			inheritFromMain.Rules = props.GetTextProps();
+
+			var entry = new DummyStyleInfo(mainTitleStyle);
+			var childEntry = new DummyStyleInfo(inheritFromMain);
+			var styleInfos = new LcmStyleSheet.StyleInfoCollection();
+			styleInfos.Add(entry);
+			styleInfos.Add(childEntry);
+			// SUT
+			childEntry.SetBasedOnStyleAndInheritValues(styleInfos);
+			var childOverrides = childEntry.FontInfoForWs(Cache.DefaultAnalWs);
+			Assert.True(childOverrides.m_fontName.IsInherited,
+				"The child entry's ws override should still inherit the fontName");
+			Assert.AreEqual("Fontastic", childOverrides.m_fontName.Value,
+				"The fontName inherited from the parent's ws override should not be clobbered by the child's default font info");
+			Assert.AreEqual("smcp=1", childOverrides.m_features.Value,
+				"The child's explicit default font features should be propagated to its ws override");
 		}
 
 		/// ------------------------------------------------------------------------------------

--- a/tests/SIL.LCModel.Tests/DomainServices/BaseStyleInfoTests.cs
+++ b/tests/SIL.LCModel.Tests/DomainServices/BaseStyleInfoTests.cs
@@ -491,6 +491,118 @@ namespace SIL.LCModel.DomainServices
 				"The child's explicit default font features should be propagated to its ws override");
 		}
 
+		/// <summary>
+		/// Tests that a child style's explicit style-level default properties are still
+		/// propagated into its ws-specific overrides (the intended behavior of LT-18109),
+		/// while properties the child does not set explicitly keep the values inherited from
+		/// the based-on style's ws override. See LT-22351.
+		/// </summary>
+		[Test]
+		public void SetBasedOnStyleAndInheritValues_ExplicitDefaultPropsPropagateIntoWsOverride()
+		{
+			// Font family override for the parent style
+			byte[] buffer = new byte[] {
+				0xC1, 0x87, 0x8B, 0x3B, // WS for english (little endian)
+				0x09, 0x00, // FF length
+				(byte)'F', 0,
+				(byte)'o', 0,
+				(byte)'n', 0,
+				(byte)'t', 0,
+				(byte)'a', 0,
+				(byte)'s', 0,
+				(byte)'t', 0,
+				(byte)'i', 0,
+				(byte)'c', 0,
+
+				0x00, 0x00, // Count of int props
+			};
+
+			ITsPropsBldr props;
+
+			var mainTitleStyle = AddTestStyle("Title Main", ContextValues.Title,
+				StructureValues.Body, FunctionValues.Prose, false, Cache.LangProject.StylesOC);
+			var inheritFromMain = AddTestStyle("Inherit Title", ContextValues.Title, StructureValues.Body,
+				FunctionValues.Prose, false, Cache.LangProject.StylesOC);
+			inheritFromMain.BasedOnRA = mainTitleStyle;
+			// The parent style has a ws-specific font override and a different default font
+			props = mainTitleStyle.Rules.GetBldr();
+			props.SetStrPropValue((int)FwTextPropType.ktptFontFamily, "Times New Roman");
+			props.SetStrPropValue((int)FwTextPropType.ktptWsStyle, DummyStyleInfo.MakeStringFromBuffer(buffer));
+			mainTitleStyle.Rules = props.GetTextProps();
+			// The child style's only explicit style-level default is bold, which the parent's
+			// ws override does not set
+			props = inheritFromMain.Rules.GetBldr();
+			props.SetIntPropValues((int)FwTextPropType.ktptBold,
+				(int)FwTextPropVar.ktpvDefault, 1);
+			inheritFromMain.Rules = props.GetTextProps();
+
+			var entry = new DummyStyleInfo(mainTitleStyle);
+			var childEntry = new DummyStyleInfo(inheritFromMain);
+			var styleInfos = new LcmStyleSheet.StyleInfoCollection();
+			styleInfos.Add(entry);
+			styleInfos.Add(childEntry);
+			// SUT
+			childEntry.SetBasedOnStyleAndInheritValues(styleInfos);
+			var childOverrides = childEntry.FontInfoForWs(Cache.DefaultAnalWs);
+			Assert.AreEqual("Fontastic", childOverrides.m_fontName.Value,
+				"The fontName inherited from the parent's ws override should not be clobbered by the child's default font info");
+			Assert.IsTrue(childOverrides.m_bold.Value,
+				"The child's explicit default bold setting should be propagated to its ws override");
+		}
+
+		/// <summary>
+		/// Tests that a child style's explicit style-level default font name applies across
+		/// writing systems: it wins over the font name in the based-on style's ws override.
+		/// See LT-22351.
+		/// </summary>
+		[Test]
+		public void SetBasedOnStyleAndInheritValues_ExplicitDefaultFontNameBeatsParentWsOverride()
+		{
+			// Font family override for the parent style
+			byte[] buffer = new byte[] {
+				0xC1, 0x87, 0x8B, 0x3B, // WS for english (little endian)
+				0x09, 0x00, // FF length
+				(byte)'F', 0,
+				(byte)'o', 0,
+				(byte)'n', 0,
+				(byte)'t', 0,
+				(byte)'a', 0,
+				(byte)'s', 0,
+				(byte)'t', 0,
+				(byte)'i', 0,
+				(byte)'c', 0,
+
+				0x00, 0x00, // Count of int props
+			};
+
+			ITsPropsBldr props;
+
+			var mainTitleStyle = AddTestStyle("Title Main", ContextValues.Title,
+				StructureValues.Body, FunctionValues.Prose, false, Cache.LangProject.StylesOC);
+			var inheritFromMain = AddTestStyle("Inherit Title", ContextValues.Title, StructureValues.Body,
+				FunctionValues.Prose, false, Cache.LangProject.StylesOC);
+			inheritFromMain.BasedOnRA = mainTitleStyle;
+			// The parent style has a ws-specific font override
+			props = mainTitleStyle.Rules.GetBldr();
+			props.SetStrPropValue((int)FwTextPropType.ktptWsStyle, DummyStyleInfo.MakeStringFromBuffer(buffer));
+			mainTitleStyle.Rules = props.GetTextProps();
+			// The child style has an explicit style-level default font name
+			props = inheritFromMain.Rules.GetBldr();
+			props.SetStrPropValue((int)FwTextPropType.ktptFontFamily, "Times New Roman");
+			inheritFromMain.Rules = props.GetTextProps();
+
+			var entry = new DummyStyleInfo(mainTitleStyle);
+			var childEntry = new DummyStyleInfo(inheritFromMain);
+			var styleInfos = new LcmStyleSheet.StyleInfoCollection();
+			styleInfos.Add(entry);
+			styleInfos.Add(childEntry);
+			// SUT
+			childEntry.SetBasedOnStyleAndInheritValues(styleInfos);
+			var childOverrides = childEntry.FontInfoForWs(Cache.DefaultAnalWs);
+			Assert.AreEqual("Times New Roman", childOverrides.m_fontName.Value,
+				"The child's explicit default font name should apply across writing systems, winning over the parent's ws override");
+		}
+
 		/// ------------------------------------------------------------------------------------
 		/// <summary>
 		/// Tests retrieving WS specific overrides from string

--- a/tests/SIL.LCModel.Tests/DomainServices/BaseStyleInfoTests.cs
+++ b/tests/SIL.LCModel.Tests/DomainServices/BaseStyleInfoTests.cs
@@ -274,6 +274,34 @@ namespace SIL.LCModel.DomainServices
 			Assert.AreEqual(false, newInfo.IsBuiltIn, "Copies of styles should not be considered built in");
 		}
 
+		/// ------------------------------------------------------------------------------------
+		/// <summary>
+		/// Tests that font features (ktptFontVariations) set as a style-level default (not a
+		/// writing-system override) are loaded into the default font info. See LT-22351: such
+		/// features were saved to the database but silently dropped when the style was reloaded,
+		/// because ProcessStyleRules had no case for ktptFontVariations.
+		/// </summary>
+		/// ------------------------------------------------------------------------------------
+		[Test]
+		public void ConstructBasedOnStyle_FontFeatures()
+		{
+			ITsPropsBldr props;
+
+			IStStyle mainTitleStyle = AddTestStyle("Title Main", ContextValues.Title,
+				StructureValues.Body, FunctionValues.Prose, false, Cache.LangProject.StylesOC);
+			props = mainTitleStyle.Rules.GetBldr();
+			props.SetStrPropValue((int)FwTextPropType.ktptFontFamily, "Arial");
+			props.SetStrPropValue((int)FwTextPropType.ktptFontVariations, "smcp=1,ss01=2");
+			mainTitleStyle.Rules = props.GetTextProps();
+
+			DummyStyleInfo entry = new DummyStyleInfo(mainTitleStyle);
+			FontInfo fontInfo = entry.FontInfoForWs(-1);
+			Assert.IsNotNull(fontInfo);
+			Assert.IsTrue(fontInfo.m_features.IsExplicit,
+				"Default font features set on the style should be explicit, not inherited");
+			Assert.AreEqual("smcp=1,ss01=2", fontInfo.m_features.Value);
+		}
+
 		/// <summary>
 		/// Minimal test of an alternate constructor to verify that it records the cache from the style.
 		/// </summary>

--- a/tests/SIL.LCModel.Tests/DomainServices/BulletInfoTests.cs
+++ b/tests/SIL.LCModel.Tests/DomainServices/BulletInfoTests.cs
@@ -139,6 +139,37 @@ namespace SIL.LCModel.DomainServices
 
 			Assert.AreEqual(expectedFontInfo, bulletInfo2.FontInfo);
 		}
+
+		/// ------------------------------------------------------------------------------------
+		/// <summary>
+		/// Tests that we can save and restore a font info that has both a font name and font
+		/// features (ktptFontVariations) explicitly set. DecodeFontInfo used to stop parsing
+		/// after the first string property, so the font features (which are encoded after the
+		/// font name) were lost on every decode. See LT-22351.
+		/// </summary>
+		/// ------------------------------------------------------------------------------------
+		[Test]
+		public void RoundTripEncodingAndDecodingOfFontInfo_FontNameAndFontFeatures()
+		{
+			// Setup what we expect
+			FontInfo expectedFontInfo = m_infoTable["TestStyle"].FontInfoForWs(-1);
+			expectedFontInfo.m_fontName = new InheritableStyleProp<string>("Algerian");
+			expectedFontInfo.m_features = new InheritableStyleProp<string>("smcp=1,ss01=2");
+
+			BulletInfo bulletInfo1 = new BulletInfo();
+			bulletInfo1.FontInfo = expectedFontInfo;
+
+			BulletInfo bulletInfo2 = new BulletInfo();
+			bulletInfo2.EncodedFontInfo = bulletInfo1.EncodedFontInfo;
+
+			Assert.IsTrue(bulletInfo2.FontInfo.m_fontName.IsExplicit,
+				"The font name should survive the round trip");
+			Assert.AreEqual("Algerian", bulletInfo2.FontInfo.m_fontName.Value);
+			Assert.IsTrue(bulletInfo2.FontInfo.m_features.IsExplicit,
+				"The font features should survive the round trip");
+			Assert.AreEqual("smcp=1,ss01=2", bulletInfo2.FontInfo.m_features.Value);
+			Assert.AreEqual(expectedFontInfo, bulletInfo2.FontInfo);
+		}
 		#endregion
 	}
 }


### PR DESCRIPTION
## Summary

Font features set as a style's *default* font (not tied to a writing system) saved correctly but silently disappeared on reload — breaking Dictionary Preview CSS generation for anyone using default-level font features.

## 1. The bug that started it all

```mermaid
flowchart LR
    A["Styles dialog<br/>sets default font features"] --> B["Save<br/>GetOverridesString serializes fine"]
    B --> C[("Database<br/>style rules blob")]
    C --> D["Load<br/>ProcessStyleRules switch"]
    D -->|"no case for ktptFontVariations"| E["Dropped"]
```

`BaseStyleInfo.ProcessStyleRules` had a case for the default font *name* but none for default font *features* (`ktptFontVariations`), so it fell to `default: break` and the value was thrown away on load. The save path and the per-writing-system override path both already understood this property; only the default-font load path didn't.

## 2. Fixing it exposed a second, older bug

Take a parent style `Title Main` with an English override of `Fontastic` and a default font of `Times New Roman`. A child style `Inherit Title` is based on it, and the *only* thing set on the child is a default font feature: `smcp=1`. What does the child's English text render in?

| | Before this PR | Fixed the obvious way (one-line) | This PR (final) |
|---|---|---|---|
| Default font features loaded? | No — no case in the switch | Yes | Yes |
| Does the child's default become "has explicit"? | No | Yes | Yes |
| What runs on the child's English override | nothing — the propagate branch never triggers | `InheritAllProperties(default)` — copies *every* default value, explicit or not | `InheritExplicitProperties(default)` — copies only values the default itself set explicitly |
| Resulting English font name | Fontastic ✅ (correct, by luck) | Times New Roman ❌ (clobbered) | Fontastic ✅ (correct, on purpose) |
| Resulting English font features | missing ❌ | smcp=1 ✅ | smcp=1 ✅ |

The middle column isn't hypothetical — it's what a one-line fix to just `ProcessStyleRules` would have produced, since fixing the load path is what makes `IsAnyExplicit` true and turns on the propagate-to-overrides branch for the first time for these styles.

Fix: only propagate default properties the style explicitly set, via new `FontInfo.InheritExplicitProperties`. Properties the default merely inherited from further up the style chain are left alone, so they no longer clobber an override's own, more specific inheritance.

## 3. The rule now, in plain terms

- **Explicitly set default → propagates.** If a style explicitly sets a default (font name, bold, features…), that value wins over whatever a based-on style's own writing-system override had. Intentional, longstanding behavior (LT-18109).
- **Merely inherited default → hands off.** If a style's default value for some property was never explicitly set — just riding along from the based-on style's default — it must not overwrite an override correctly inherited from the based-on style's own writing-system override.

## 4. A third, smaller bug found along the way: bullet fonts

`BulletInfo.DecodeFontInfo` stopped reading an encoded blob after the first string property, so a bullet with both a custom font name *and* font features lost the features on decode:

| Encoded property (in order) | Before (`break`) | Now (`continue`) |
|---|---|---|
| `ktptFontFamily` = "Algerian" | read | read |
| `ktptFontVariations` = "smcp=1,ss01=2" | never reached — loop exits | read |

One-character fix: `break` → `continue`.

## Tests

- Default font features round-trip through save/load.
- The clobber, pinned failing-before / passing-after.
- Explicit defaults still correctly propagate to overrides (LT-18109 behavior preserved).
- Explicit default font name still wins across writing systems.
- Bullet font decode round-trips both font name and features.

Full suite green on net462 and net8.0 (SIL.LCModel.Tests 1706/1706, SIL.LCModel.Core.Tests 787/787, SIL.LCModel.Utils.Tests 302 passed/2 skipped, SIL.LCModel.FixData.Tests 21/21) — no regressions.

References JIRA [LT-22351](https://jira.sil.org/browse/LT-22351). A companion FieldWorks PR ([#1005](https://github.com/sillsdev/FieldWorks/pull/1005)) will consume this liblcm fix once merged and released.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [![Reviewable](https://reviewable.io/review_button.svg)](https://reviewable.io/reviews/sillsdev/liblcm/388)
<!-- Reviewable:end -->