### PR TITLE
Trim overwordy semantic domain descriptions in SemDom.xml template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 
+- [SIL.LCModel] Trim 12 overwordy semantic domain descriptions in the SemDom.xml template, matching sillsdev/FwLocalizations#5
 - [SIL.LCModel] `FileUtils.IsFileUriOrPath` checks for the presence of "file:" rather than the absence of known non-file URI schemes
 - Changed to target .Net Framework 4.6.2 instead of 4.6.1
 - Update libPalaso dependency from version 14.2.0-* to 17.0.0-*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,7 +39,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 
-- [SIL.LCModel] Trim 12 overwordy semantic domain descriptions in the SemDom.xml template, matching sillsdev/FwLocalizations#5
+- [SIL.LCModel] Trim 12 overwordy semantic domain descriptions and fix 22 punctuation/whitespace issues in the SemDom.xml template, matching sillsdev/FwLocalizations#5 and sillsdev/FwLocalizations#7
 - [SIL.LCModel] `FileUtils.IsFileUriOrPath` checks for the presence of "file:" rather than the absence of known non-file URI schemes
 - Changed to target .Net Framework 4.6.2 instead of 4.6.1
 - Update libPalaso dependency from version 14.2.0-* to 17.0.0-*

--- a/src/SIL.LCModel/Templates/SemDom.xml
+++ b/src/SIL.LCModel/Templates/SemDom.xml
@@ -4194,7 +4194,7 @@
 </Name>
 <Description>
 <AStr ws="en">
-<Run ws="en">Use this domain for general words for all plants. Use a book of pictures to identify plant names and the scientific name. Languages divide plants into various domains that are not always comparable from language to language. Criterial features may be characteristics (trees and bushes are distinguished by size and number of trunks) and use (grass and weeds are distinguished by their desirability). A common distinction is between trees and non-trees, with trees described as being big, woody, and having a life expectancy of several years, while non-trees are small, non-woody, and have a life expectancy of typically not more than one year (Heine, Bernd and Karsten Legere. 1995. Swahili plants. Rudiger Koppe Verlag: Koln.). Agricultural societies will divide plants into wild and cultivated. However most plants for which there are names have some use. Therefore it does not seem helpful to divide plant names into domains for useful and non-useful plants. Since only parts of plants are eaten, edible parts of plants are listed under the domain 'Food'. Some languages may have more domains than are used in this list, others may have fewer. The classification system used here does not agree entirely with the system used by botanists. For instance botanists do not classify all the tree species together. The palm trees belong to the class Monocotyledoneae and are classified with lilies, bananas, and orchids. Apple and cherry trees belong to the class Dicotyledoneae and are classified in the rose family along with roses and blackberries. The acacia tree also belongs to the class Dicotyledoneae and is classified in the pulse family along with lupines and beans. However most folk taxonomies bring all the trees together. The scientific classification system for plants and animals is taken from: Carruth, Gorton, ed. 1989. The Volume Library, Vols. 1 and 2. The Southwestern Company: Nashville.</Run>
+<Run ws="en">Use this domain for general words for all plants. Use a book of pictures to identify plant names and the scientific name. Languages divide plants into various domains that are not always comparable from language to language. Some languages may have more domains than are used in this list, others may have fewer. The classification system used here does not agree entirely with the system used by botanists. For instance botanists do not classify all the tree species together. However most folk taxonomies bring all the trees together.</Run>
 </AStr>
 </Description>
 <OcmCodes>
@@ -35265,7 +35265,7 @@
 </Name>
 <Description>
 <AStr ws="en">
-<Run ws="en">Use this domain for words related to a particular game. The example words are from the card games. If you do not play card games in your culture, you can rename this domain and use it for one of your games. Add other domains for each of your games.</Run>
+<Run ws="en">Use this domain for words related to a particular game. If you do not play card games in your culture, you can rename this domain and use it for one of your games.</Run>
 </AStr>
 </Description>
 <Questions>
@@ -35336,7 +35336,7 @@
 </Name>
 <Description>
 <AStr ws="en">
-<Run ws="en">Use this domain for words related to a particular game. The example words are from the game of chess. If you do not play chess in your culture, you can rename this domain and use it for one of your games. Add other domains for each of your games.</Run>
+<Run ws="en">Use this domain for words related to a particular game. If you do not play chess in your culture, you can rename this domain and use it for one of your games.</Run>
 </AStr>
 </Description>
 <Questions>
@@ -35611,7 +35611,7 @@
 </Name>
 <Description>
 <AStr ws="en">
-<Run ws="en">Use this domain for words related to a particular sport. The example words are from the sport of football (also called soccer). If you do not play football in your culture, you can rename this domain and use it for one of your sports. Add other domains for each of your sports.</Run>
+<Run ws="en">Use this domain for words related to a particular sport. If you do not play football or soccer in your culture, you can rename this domain and use it for one of your sports.</Run>
 </AStr>
 </Description>
 <Questions>
@@ -35722,7 +35722,7 @@
 </Name>
 <Description>
 <AStr ws="en">
-<Run ws="en">Use this domain for words related to a particular sport. The example words are from the sport of basketball. If you do not play basketball in your culture, you can rename this domain and use it for one of your sports. Add other domains for each of your sports.</Run>
+<Run ws="en">Use this domain for words related to a particular sport. If you do not play basketball in your culture, you can rename this domain and use it for one of your sports.</Run>
 </AStr>
 </Description>
 <Questions>
@@ -46456,7 +46456,7 @@
 </Name>
 <Description>
 <AStr ws="en">
-<Run ws="en">Use this domain for words related to sacred writings. Examples are only given for the Christian sacred writings. However you should include words referring to the holy books of all religions .</Run>
+<Run ws="en">Use this domain for words related to sacred writings. You should include words referring to the holy books of all religions .</Run>
 </AStr>
 </Description>
 <Questions>
@@ -47674,7 +47674,7 @@
 </Name>
 <Description>
 <AStr ws="en">
-<Run ws="en">Use this domain for words referring to religious practitioners--people who practice a religion, who are members of the religion, believe in the religion, leaders of the religion, and followers of the religion. Each religion has its own terms for religious practitioners. List these terms separately for each religion. The examples given below are for the Christian religion.</Run>
+<Run ws="en">Use this domain for words referring to religious practitioners--people who practice a religion, who are members of the religion, believe in the religion, leaders of the religion, and followers of the religion. Each religion has its own terms for religious practitioners. List these terms separately for each religion.</Run>
 </AStr>
 </Description>
 <OcmCodes>
@@ -48587,7 +48587,7 @@
 </Name>
 <Description>
 <AStr ws="en">
-<Run ws="en">Use this domain for words referring to various ways of cooking food. It is necessary to think through different kinds of food and how they are cooked. An example is given below for cooking eggs.</Run>
+<Run ws="en">Use this domain for words referring to various ways of cooking food. It is necessary to think through different kinds of food and how they are cooked.</Run>
 </AStr>
 </Description>
 <Questions>
@@ -50934,7 +50934,7 @@
 </Name>
 <Description>
 <AStr ws="en">
-<Run ws="en">Use this domain for words referring to special clothes worn on special occasions. It is necessary to think through all the various special occasions in the culture and think of any special clothes worn on those occasions. Two examples are given below for work and graduation, but there are many others.</Run>
+<Run ws="en">Use this domain for words referring to special clothes worn on special occasions. It is necessary to think through all the various special occasions in the culture and think of any special clothes worn on those occasions.</Run>
 </AStr>
 </Description>
 <OcmCodes>
@@ -50976,7 +50976,7 @@
 </Name>
 <Description>
 <AStr ws="en">
-<Run ws="en">Use this domain for special clothes worn by special people. It is necessary to think through all the various special types of people in the culture and think of any special clothes worn by them. Several examples are given below, but there are many others.</Run>
+<Run ws="en">Use this domain for special clothes worn by special people. It is necessary to think through all the various special types of people in the culture and think of any special clothes worn by them.</Run>
 </AStr>
 </Description>
 <Questions>
@@ -90239,7 +90239,7 @@
 </Name>
 <Description>
 <AStr ws="en">
-<Run ws="en">Use this domain to list all adjectives. If there are many adjectives in your language, you should not try to list them all here. If you want to find all the adjectives, most dictionary programs can sort your dictionary by part of speech. However if your language only has a few adjectives, you can list them all in this domain. In the book, "Where Have All the Adjectives Gone?" R. M. W. Dixon [Dixon, R. M. W. 1982. Where have all the adjectives gone? Berlin: Mouton.] identifies seven universal semantic types that are often expressed by adjectives. They are: Age (new, young, old), Dimension (big, little, long, short, wide, narrow, thick, fat, thin), Value (good, bad, proper, perfect, excellent, fine, delicious, atrocious, poor), Color (black, white, red), Human propensity (jealous, happy, kind, clever, generous, cruel, rude, proud, wicked), Physical property (hard, soft, heavy, light, rough, smooth, hot, cold, sweet, sour), Speed (fast, slow). Words in the Human propensity class may be nouns. Words in the Physical property and Speed classes may be verbs.</Run>
+<Run ws="en">Use this domain to list all adjectives. If there are many adjectives in your language, you should not try to list them all here. If you want to find all the adjectives, most dictionary programs can sort your dictionary by part of speech. However if your language only has a few adjectives, you can list them all in this domain. [Dixon, R. M. W. 1982. Where have all the adjectives gone? Berlin: Mouton.] identifies seven universal semantic types that are often expressed by adjectives. They are: Age, Dimension, Value, Color, Human propensity, Physical property, Speed. Words in the Human propensity class may be nouns. Words in the Physical property and Speed classes may be verbs.</Run>
 </AStr>
 </Description>
 <Questions>
@@ -95516,7 +95516,7 @@
 </Name>
 <Description>
 <AStr ws="en">
-<Run ws="en">Use this domain for words that the speaker uses to show respect or a lack of respect to the person he is addressing. Some languages have elaborate systems of honorifics. Other languages have none. Languages with a stratified social structure often use honorifics. Egalitarian societies generally lack them, but some egalitarian societies may use them. For instance in Nahuatl there are four levels of honorifics. Level 1 is how one addresses intimates, small children, and pets. Level 2 is for strangers and persons treated formally. Level 3 is for respected persons, the dead, and God. Level 4 is for obsequious respect, as for the archbishop in an interview with a priest, and for ritual kin. (Jane H. Hill and Kenneth C. Hill. 1978. Honorific usage in modern Nahuatl: the expression of social distance and respect in the Nahuatl of the Malinche Volcano area, Language 54:123-155.) In Japanese, which has a stratified social structure, a person uses one set of words and affixes when speaking to someone below you in the social hierarchy, such as your wife, children, and pets. A different set of words is used when speaking to peers. Another set is used when speaking to a superior. A fourth set is used when speaking to the emperor. English used to have two pronouns for second person singular. 'Thou' was used for equals and inferiors, and 'you' was used for superiors. Your language may have special honorific words used as (1) pronouns, (2) affixes, (3) particles, (4) terms of direct address, (5) greetings (6) requests, (7) apologies.</Run>
+<Run ws="en">Use this domain for words that the speaker uses to show respect or a lack of respect to the person he is addressing. Some languages have elaborate systems of honorifics. Other languages have none. Languages with a stratified social structure often use honorifics. Egalitarian societies generally lack them, but some egalitarian societies may use them. For instance, in Japanese, which has a stratified social structure, a person uses one set of words and affixes when speaking to someone below him in the social hierarchy, such as his wife, children, and pets. A different set of words is used when speaking to peers. Another set is used when speaking to a superior. A fourth set is used when speaking to the emperor. Your language may have special honorific words used as (1) pronouns, (2) affixes, (3) particles, (4) terms of direct address, (5) greetings, (6) requests, (7) apologies.</Run>
 </AStr>
 </Description>
 <Questions>

--- a/src/SIL.LCModel/Templates/SemDom.xml
+++ b/src/SIL.LCModel/Templates/SemDom.xml
@@ -6086,7 +6086,7 @@
 <AUni ws="en">(2) What are the parts of the head?</AUni>
 </Question>
 <ExampleWords>
-<AUni ws="en">head, ear, eye, nose, muzzle, maw, snout, trunk (of an elephant), proboscis, mouth, tooth, fang , tusk, tongue, neck, horn, antler, dewlap</AUni>
+<AUni ws="en">head, ear, eye, nose, muzzle, maw, snout, trunk (of an elephant), proboscis, mouth, tooth, fang, tusk, tongue, neck, horn, antler, dewlap</AUni>
 </ExampleWords>
 </CmDomainQ>
 <CmDomainQ>
@@ -13626,7 +13626,7 @@
 </Name>
 <Description>
 <AStr ws="en">
-<Run ws="en">Use this domain for words related to pain</Run>
+<Run ws="en">Use this domain for words related to pain.</Run>
 </AStr>
 </Description>
 <LouwNidaCodes>
@@ -16863,7 +16863,7 @@
 </Name>
 <Description>
 <AStr ws="en">
-<Run ws="en">Use this domain for words related to old age and older persons?</Run>
+<Run ws="en">Use this domain for words related to old age and older persons.</Run>
 </AStr>
 </Description>
 <OcmCodes>
@@ -18996,7 +18996,7 @@
 </CmDomainQ>
 <CmDomainQ>
 <Question>
-<AUni ws="en">(3) What words refer to not being able to think well? </AUni>
+<AUni ws="en">(3) What words refer to not being able to think well?</AUni>
 </Question>
 <ExampleWords>
 <AUni ws="en">derangement, idiocy, imbecility, insanity, lunacy, madness, senility, stupidity</AUni>
@@ -29280,7 +29280,7 @@
 </Name>
 <Description>
 <AStr ws="en">
-<Run ws="en">Use this domain for words referring to admitting something--saying that you have done wrong, or that your beliefs were wrong</Run>
+<Run ws="en">Use this domain for words referring to admitting something--saying that you have done wrong, or that your beliefs were wrong.</Run>
 </AStr>
 </Description>
 <LouwNidaCodes>
@@ -39285,7 +39285,7 @@
 </Name>
 <Description>
 <AStr ws="en">
-<Run ws="en">Use this domain for general words referring to prosperity and trouble</Run>
+<Run ws="en">Use this domain for general words referring to prosperity and trouble.</Run>
 </AStr>
 </Description>
 <LouwNidaCodes>
@@ -42291,7 +42291,7 @@
 </Name>
 <Description>
 <AStr ws="en">
-<Run ws="en">Use this domain for words related to the countryside--the area away from a city</Run>
+<Run ws="en">Use this domain for words related to the countryside--the area away from a city.</Run>
 </AStr>
 </Description>
 <LouwNidaCodes>
@@ -46456,7 +46456,7 @@
 </Name>
 <Description>
 <AStr ws="en">
-<Run ws="en">Use this domain for words related to sacred writings. You should include words referring to the holy books of all religions .</Run>
+<Run ws="en">Use this domain for words related to sacred writings. You should include words referring to the holy books of all religions.</Run>
 </AStr>
 </Description>
 <Questions>
@@ -63439,7 +63439,7 @@
 </CmDomainQ>
 <CmDomainQ>
 <Question>
-<AUni ws="en">(2) What words refer to money given to a person for betraying or murdering someone.</AUni>
+<AUni ws="en">(2) What words refer to money given to a person for betraying or murdering someone?</AUni>
 </Question>
 <ExampleWords>
 <AUni ws="en">murder money, blood money, cursed money</AUni>
@@ -64413,7 +64413,7 @@
 <Questions>
 <CmDomainQ>
 <Question>
-<AUni ws="en">(1) What words refer to moving a part of your body forward or out? </AUni>
+<AUni ws="en">(1) What words refer to moving a part of your body forward or out?</AUni>
 </Question>
 <ExampleWords>
 <AUni ws="en">extend, hold out, put out, stick out, stretch</AUni>
@@ -68210,7 +68210,7 @@
 </Name>
 <Description>
 <AStr ws="en">
-<Run ws="en">Use this domain for verbs for catching something that is thrown or dropped</Run>
+<Run ws="en">Use this domain for verbs for catching something that is thrown or dropped.</Run>
 </AStr>
 </Description>
 <Questions>
@@ -69569,7 +69569,7 @@
 </Name>
 <Description>
 <AStr ws="en">
-<Run ws="en">Use this domain for words referring to preventing someone or something from moving</Run>
+<Run ws="en">Use this domain for words referring to preventing someone or something from moving.</Run>
 </AStr>
 </Description>
 <Questions>
@@ -74674,7 +74674,7 @@
 </CmDomainQ>
 <CmDomainQ>
 <Question>
-<AUni ws="en">(3) What words indicate that most of a group is of one kind.</AUni>
+<AUni ws="en">(3) What words indicate that most of a group is of one kind?</AUni>
 </Question>
 <ExampleWords>
 <AUni ws="en">mostly, mainly, largely, predominantly, predominate, be in the majority, a preponderance</AUni>
@@ -79703,7 +79703,7 @@
 </Name>
 <Description>
 <AStr ws="en">
-<Run ws="en">Use this domain for words that describe something that is symmetrical--having the same shape on both sides</Run>
+<Run ws="en">Use this domain for words that describe something that is symmetrical--having the same shape on both sides.</Run>
 </AStr>
 </Description>
 <Questions>
@@ -90091,7 +90091,7 @@
 </CmDomainQ>
 <CmDomainQ>
 <Question>
-<AUni ws="en">(2) What words refer to a situation that affects what can happen or what people can do? </AUni>
+<AUni ws="en">(2) What words refer to a situation that affects what can happen or what people can do?</AUni>
 </Question>
 <ExampleWords>
 <AUni ws="en">situation, circumstances, environment, climate, conditions, the lay of the land, which way the wind blows, scenario</AUni>
@@ -91506,7 +91506,7 @@
 </CmDomainQ>
 <CmDomainQ>
 <Question>
-<AUni ws="en">(17) gnomic present: the situation described in the proposition is generic; the predicate has held, holds, and will hold for the class of entities named by the subject, such as 'Elephants have trunks'. </AUni>
+<AUni ws="en">(17) gnomic present: the situation described in the proposition is generic; the predicate has held, holds, and will hold for the class of entities named by the subject, such as 'Elephants have trunks'.</AUni>
 </Question>
 </CmDomainQ>
 <CmDomainQ>
@@ -92123,7 +92123,7 @@
 </CmDomainQ>
 <CmDomainQ>
 <Question>
-<AUni ws="en">(10) strong: (self-explanatory). </AUni>
+<AUni ws="en">(10) strong: (self-explanatory).</AUni>
 </Question>
 </CmDomainQ>
 <CmDomainQ>
@@ -92170,7 +92170,7 @@
 <Questions>
 <CmDomainQ>
 <Question>
-<AUni ws="en">(1) What words indicate that the speaker is encouraging or inciting someone to action.</AUni>
+<AUni ws="en">(1) What words indicate that the speaker is encouraging or inciting someone to action?</AUni>
 </Question>
 <ExampleWords>
 <AUni ws="en">urge, request, let, why don't, please</AUni>
@@ -93217,7 +93217,7 @@
 </CmDomainQ>
 <CmDomainQ>
 <Question>
-<AUni ws="en">(3) What are the noun forms of these words? </AUni>
+<AUni ws="en">(3) What are the noun forms of these words?</AUni>
 </Question>
 </CmDomainQ>
 </Questions>
@@ -93356,7 +93356,7 @@
 </CmDomainQ>
 <CmDomainQ>
 <Question>
-<AUni ws="en">(12) subordinator: marker indicates that the verb is in a subordinate clause. </AUni>
+<AUni ws="en">(12) subordinator: marker indicates that the verb is in a subordinate clause.</AUni>
 </Question>
 </CmDomainQ>
 </Questions>
@@ -95852,7 +95852,7 @@
 </Name>
 <Description>
 <AStr ws="en">
-<Run ws="en">Use this domain for common nicknames--an additional name given to a person later in life, often descriptive. Also include general names used to call or refer to someone when you don't know their name</Run>
+<Run ws="en">Use this domain for common nicknames--an additional name given to a person later in life, often descriptive. Also include general names used to call or refer to someone when you don't know their name.</Run>
 </AStr>
 </Description>
 <Questions>
@@ -95866,7 +95866,7 @@
 </CmDomainQ>
 <CmDomainQ>
 <Question>
-<AUni ws="en">(2) What names are used to refer to someone when you don't know their name.</AUni>
+<AUni ws="en">(2) What names are used to refer to someone when you don't know their name?</AUni>
 </Question>
 <ExampleWords>
 <AUni ws="en">John Doe, Jane Doe, Joe Blow, GI Joe</AUni>


### PR DESCRIPTION
Resolves #390

Applies to `src/SIL.LCModel/Templates/SemDom.xml` (the canonical FLEx new-project template) the same 12 English description trims that sillsdev/FwLocalizations#5 made to the Crowdin source (`lists/LocalizableLists.xml`): removing references to the removed example words, meta "add other domains" instructions, and overwordy citation passages.

Affected domains:

| Domain | Trim |
|---|---|
| 1.5 Plant | Botanical-classification citation passages |
| 4.2.6.1.1 Card game | "The example words are from…" + "Add other domains…" |
| 4.2.6.1.2 Chess | "The example words are from…" + "Add other domains…" |
| 4.2.6.2.1 Football, soccer | "The example words are from…" + "Add other domains…" |
| 4.2.6.2.2 Basketball | "The example words are from…" + "Add other domains…" |
| 4.9.3.1 Sacred writings | "Examples are only given for…" |
| 4.9.7.1 Religious person | "The examples given below are for…" |
| 5.2.1.1 Cooking methods | "An example is given below…" |
| 5.3.4 Clothes for special occasions | "Two examples are given below…" |
| 5.3.5 Clothes for special people | "Several examples are given below…" |
| 9.2.1 Adjectives | Dixon citation passage condensed |
| 9.6.3.8 Honorifics | Nahuatl citation passage removed; example condensed |

Also applies the 22 punctuation/whitespace fixes from the follow-up sillsdev/FwLocalizations#7 ("Fix semantic domain punctuation and spaces"):

| Fix | Count | Domains |
|---|---|---|
| Missing terminal period added to `Description` | 8 | Pain, Confession, Prosperity and Trouble, Countryside, Catch, Prevent, Symmetrical, Nicknames |
| Wrong terminal punctuation fixed (`.`↔`?`) | 5 | Old age; Blood money, Majority, Encourage/Incite, Nicknames (Questions) |
| Stray trailing space before closing tag removed | 7 | Insanity, Body movement, Situation/circumstances, Gnomic present, Strong (self-explanatory), Noun forms, Subordinator |
| Stray space before punctuation removed | 2 | Head `ExampleWords`, Sacred writings `Description` |

The old/new strings for both sets were extracted verbatim from the respective FwLocalizations PR diffs and applied programmatically; each of the 34 old strings occurred exactly once in `SemDom.xml`, and the resulting texts are byte-identical to the new strings in `lists/LocalizableLists.xml`. Also adds a CHANGELOG entry under Unreleased.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Devin: https://app.devin.ai/review/sillsdev/liblcm/pull/391

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/liblcm/391)
<!-- Reviewable:end -->
