### PR TITLE
Replace StructureMap IoC container with Microsoft IoC

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 
+- [SIL.LCModel] Replaced the internal StructureMap (`structuremap.patched`) IoC container with `Microsoft.Extensions.DependencyInjection` (8.x). No public API change.
 - [SIL.LCModel] `FileUtils.IsFileUriOrPath` checks for the presence of "file:" rather than the absence of known non-file URI schemes
 - Changed to target .Net Framework 4.6.2 instead of 4.6.1
 - Update libPalaso dependency from version 14.2.0-* to 17.0.0-*

--- a/src/SIL.LCModel/Application/Impl/DomainDataByFlid.cs
+++ b/src/SIL.LCModel/Application/Impl/DomainDataByFlid.cs
@@ -42,7 +42,7 @@ namespace SIL.LCModel.Application.Impl
 		/// Therefore, one should not use them for multi-session identity.
 		/// CmObject identity can only be guaranteed by using their Guids (or using '==' in code).
 		/// </remarks>
-		internal DomainDataByFlid(ICmObjectRepository cmObjectRepository, IStTextRepository stTxtRepository,
+		public DomainDataByFlid(ICmObjectRepository cmObjectRepository, IStTextRepository stTxtRepository,
 			IFwMetaDataCacheManaged mdc, ISilDataAccessHelperInternal uowService,
 			ILgWritingSystemFactory wsf)
 		{

--- a/src/SIL.LCModel/ILcmServiceLocator.cs
+++ b/src/SIL.LCModel/ILcmServiceLocator.cs
@@ -117,9 +117,9 @@ namespace SIL.LCModel
 
 		public static IEnumerable<TService> GetAllInstances<TService>(this IServiceProvider provider)
 		{
-			//structure map might not work the same way as the standard service provider, so we need to handle it separately.
+			// A CommonServiceLocator-based provider exposes GetAllInstances directly.
 			if (provider is IServiceLocator serviceLocator) return serviceLocator.GetAllInstances<TService>();
-			//the standard service provider handles listing all services like this, however that might not work the same in structure map if an IEnumerable is explicitly registered.
+			// A plain IServiceProvider resolves all registrations as an IEnumerable<T>.
 			return (IEnumerable<TService>) provider.GetService(typeof(IEnumerable<TService>));
 		}
 	}

--- a/src/SIL.LCModel/IOC/LcmServiceLocatorFactory.cs
+++ b/src/SIL.LCModel/IOC/LcmServiceLocatorFactory.cs
@@ -8,6 +8,7 @@ using System.Diagnostics;
 using System.IO;
 using System.Runtime.InteropServices;
 using CommonServiceLocator;
+using Microsoft.Extensions.DependencyInjection;
 using SIL.LCModel.Application;
 using SIL.LCModel.Application.Impl;
 using SIL.LCModel.Core.KernelInterfaces;
@@ -18,8 +19,6 @@ using SIL.LCModel.DomainServices.DataMigration;
 using SIL.LCModel.Infrastructure;
 using SIL.LCModel.Infrastructure.Impl;
 using SIL.Reporting;
-using StructureMap;
-using StructureMap.Pipeline;
 
 namespace SIL.LCModel.IOC
 {
@@ -65,77 +64,52 @@ namespace SIL.LCModel.IOC
 			{
 				logger = new FileTransactionLogger(Path.Combine(logPath, $"lcm_transaction.{DateTime.Now.Ticks}.log"));
 			}
-			// NOTE: When creating an object through IServiceLocator.GetInstance the caller has
-			// to call Dispose() on the newly created object, unless it's a singleton
-			// (registered with LifecycleIs(new SingletonLifecycle())) in which case
-			// the Registry will dispose the object.
-			var registry = new Registry();
 
-			// NB: Default is:
-			// .CacheBy(InstanceScope.PerRequest);
+			// All registrations are explicit factory lambdas that call the (often internal)
+			// constructors directly. This is legal because all registration code lives inside
+			// SIL.LCModel, and it makes the whole object graph compile-time checked: a changed
+			// constructor breaks the build here instead of failing at runtime resolution.
+			var services = new ServiceCollection();
 
 			// Add data migration manager. (new one per request)
-			registry
-				.For<IDataMigrationManager>()
-				.Use<LcmDataMigrationManager>();
+			services.AddTransient<IDataMigrationManager>(sp => new LcmDataMigrationManager());
 
 			// Add HomographConfiguration
-			registry
-				.For<HomographConfiguration>()
-				.LifecycleIs(new SingletonLifecycle())
-				.Use<HomographConfiguration>();
+			services.AddSingleton<HomographConfiguration>(sp => new HomographConfiguration());
 
 			// Add LcmCache
-			registry
-				.For<LcmCache>()
-				.LifecycleIs(new SingletonLifecycle())
-				.Use<LcmCache>();
+			services.AddSingleton<LcmCache>(sp => new LcmCache());
+
 			// Add IParagraphCounterRepository
-			registry
-				.For<IParagraphCounterRepository>()
-				.LifecycleIs(new SingletonLifecycle())
-				.Use<ParagraphCounterRepository>();
+			services.AddSingleton<IParagraphCounterRepository>(sp =>
+				new ParagraphCounterRepository(sp.GetRequiredService<LcmCache>()));
 
 			// Add MDC
-			registry
-				.For<IFwMetaDataCacheManaged>()
-				.LifecycleIs(new SingletonLifecycle())
-				.Use<LcmMetaDataCache>();
+			services.AddSingleton<IFwMetaDataCacheManaged>(sp => new LcmMetaDataCache());
 			// Register its other interface.
-			registry
-				.For<IFwMetaDataCacheManagedInternal>()
-				.Use(c => (IFwMetaDataCacheManagedInternal)c.GetInstance<IFwMetaDataCacheManaged>());
+			services.AddTransient<IFwMetaDataCacheManagedInternal>(sp =>
+				(IFwMetaDataCacheManagedInternal)sp.GetRequiredService<IFwMetaDataCacheManaged>());
 
 			// Add Virtuals
-			registry
-				.For<Virtuals>()
-				.LifecycleIs(new SingletonLifecycle())
-				.Use<Virtuals>();
+			services.AddSingleton<Virtuals>(sp =>
+				new Virtuals(sp.GetRequiredService<IFwMetaDataCacheManaged>()));
 
 			// Add IdentityMap
-			registry
-				.For<IdentityMap>()
-				.LifecycleIs(new SingletonLifecycle())
-				.Use<IdentityMap>();
+			services.AddSingleton<IdentityMap>(sp =>
+				new IdentityMap(sp.GetRequiredService<IFwMetaDataCacheManaged>()));
 			// Register IdentityMap's other interface.
-			registry
-				.For<ICmObjectIdFactory>()
-				.Use(c => (ICmObjectIdFactory)c.GetInstance<IdentityMap>());
-			registry
-				.For<ICmObjectRepositoryInternal>()
-				.Use(c => (ICmObjectRepositoryInternal)c.GetInstance<ICmObjectRepository>());
+			services.AddTransient<ICmObjectIdFactory>(sp =>
+				(ICmObjectIdFactory)sp.GetRequiredService<IdentityMap>());
+			services.AddTransient<ICmObjectRepositoryInternal>(sp =>
+				(ICmObjectRepositoryInternal)sp.GetRequiredService<ICmObjectRepository>());
 
 			// Add surrogate factory (internal);
-			registry
-				.For<ICmObjectSurrogateFactory>()
-				.LifecycleIs(new SingletonLifecycle())
-				.Use<CmObjectSurrogateFactory>();
+			services.AddSingleton<ICmObjectSurrogateFactory>(sp =>
+				new CmObjectSurrogateFactory(sp.GetRequiredService<LcmCache>()));
 
 			// Add surrogate repository (internal);
-			registry
-				.For<ICmObjectSurrogateRepository>()
-				.LifecycleIs(new SingletonLifecycle())
-				.Use<CmObjectSurrogateRepository>();
+			services.AddSingleton<ICmObjectSurrogateRepository>(sp =>
+				new CmObjectSurrogateRepository(sp.GetRequiredService<IdentityMap>()));
 
 			// Add BEP.
 			switch (m_backendProviderType)
@@ -143,147 +117,154 @@ namespace SIL.LCModel.IOC
 				default:
 					throw new InvalidOperationException(Strings.ksInvalidBackendProviderType);
 				case BackendProviderType.kXML:
-					registry
-						.For<IDataSetup>()
-						.LifecycleIs(new SingletonLifecycle())
-						.Use<XMLBackendProvider>();
+					services.AddSingleton<IDataSetup>(sp => new XMLBackendProvider(
+						sp.GetRequiredService<LcmCache>(),
+						sp.GetRequiredService<IdentityMap>(),
+						sp.GetRequiredService<ICmObjectSurrogateFactory>(),
+						sp.GetRequiredService<IFwMetaDataCacheManagedInternal>(),
+						sp.GetRequiredService<IDataMigrationManager>(),
+						sp.GetRequiredService<ILcmUI>(),
+						sp.GetRequiredService<ILcmDirectories>(),
+						sp.GetRequiredService<LcmSettings>()));
 					break;
 				case BackendProviderType.kMemoryOnly:
-					registry
-						.For<IDataSetup>()
-						.LifecycleIs(new SingletonLifecycle())
-						.Use<MemoryOnlyBackendProvider>();
+					services.AddSingleton<IDataSetup>(sp => new MemoryOnlyBackendProvider(
+						sp.GetRequiredService<LcmCache>(),
+						sp.GetRequiredService<IdentityMap>(),
+						sp.GetRequiredService<ICmObjectSurrogateFactory>(),
+						sp.GetRequiredService<IFwMetaDataCacheManagedInternal>(),
+						sp.GetRequiredService<IDataMigrationManager>(),
+						sp.GetRequiredService<ILcmUI>(),
+						sp.GetRequiredService<ILcmDirectories>(),
+						sp.GetRequiredService<LcmSettings>()));
 					break;
 				case BackendProviderType.kSharedXML:
-					registry
-						.For<IDataSetup>()
-						.LifecycleIs(new SingletonLifecycle())
-						.Use<SharedXMLBackendProvider>();
+					services.AddSingleton<IDataSetup>(sp => new SharedXMLBackendProvider(
+						sp.GetRequiredService<LcmCache>(),
+						sp.GetRequiredService<IdentityMap>(),
+						sp.GetRequiredService<ICmObjectSurrogateFactory>(),
+						sp.GetRequiredService<IFwMetaDataCacheManagedInternal>(),
+						sp.GetRequiredService<IDataMigrationManager>(),
+						sp.GetRequiredService<ILcmUI>(),
+						sp.GetRequiredService<ILcmDirectories>(),
+						sp.GetRequiredService<LcmSettings>()));
 					break;
 			}
 			// Register two additional interfaces of the BEP, which are injected into other services.
-			registry
-				.For<IDataStorer>()
-				.Use(c => (IDataStorer)c.GetInstance<IDataSetup>());
-			registry
-				.For<IDataReader>()
-				.Use(c => (IDataReader)c.GetInstance<IDataSetup>());
+			services.AddTransient<IDataStorer>(sp => (IDataStorer)sp.GetRequiredService<IDataSetup>());
+			services.AddTransient<IDataReader>(sp => (IDataReader)sp.GetRequiredService<IDataSetup>());
 
 			// Add Mediator
-			registry
-				.For<IUnitOfWorkService>()
-				.LifecycleIs(new SingletonLifecycle())
-				.Use<UnitOfWorkService>();
+			services.AddSingleton<IUnitOfWorkService>(sp => new UnitOfWorkService(
+				sp.GetRequiredService<IDataStorer>(),
+				sp.GetRequiredService<IdentityMap>(),
+				sp.GetRequiredService<ICmObjectRepositoryInternal>(),
+				sp.GetRequiredService<ILcmUI>(),
+				logger));
 			// Register additional interfaces for the UnitOfWorkService.
-			registry
-				.For<ISilDataAccessHelperInternal>()
-				.Use(c => (ISilDataAccessHelperInternal)c.GetInstance<IUnitOfWorkService>());
-			registry
-				.For<IActionHandler>()
-				.Use(c => ((UnitOfWorkService)c.GetInstance<IUnitOfWorkService>()).ActiveUndoStack);
-			registry
-				.For<IWorkerThreadReadHandler>()
-				.Use(c => (IWorkerThreadReadHandler)c.GetInstance<IUnitOfWorkService>());
-			registry
-				.For<IUndoStackManager>()
-				.Use(c => (IUndoStackManager)c.GetInstance<IUnitOfWorkService>());
-			registry.For<ITransactionLogger>().Use(() => logger);
+			services.AddTransient<ISilDataAccessHelperInternal>(sp =>
+				(ISilDataAccessHelperInternal)sp.GetRequiredService<IUnitOfWorkService>());
+			// IActionHandler is deliberately transient: it returns the current ActiveUndoStack,
+			// which changes over the life of the UnitOfWorkService, so it must be re-evaluated
+			// on every resolution.
+			services.AddTransient<IActionHandler>(sp =>
+				((UnitOfWorkService)sp.GetRequiredService<IUnitOfWorkService>()).ActiveUndoStack);
+			services.AddTransient<IWorkerThreadReadHandler>(sp =>
+				(IWorkerThreadReadHandler)sp.GetRequiredService<IUnitOfWorkService>());
+			services.AddTransient<IUndoStackManager>(sp =>
+				(IUndoStackManager)sp.GetRequiredService<IUnitOfWorkService>());
+			if (logger != null)
+				services.AddSingleton<ITransactionLogger>(logger);
+
 			// Add generated factories.
-			AddFactories(registry);
+			AddFactories(services);
 
 			// Add generated Repositories
-			AddRepositories(registry);
+			AddRepositories(services);
 
 			// Add IAnalysisRepository
-			registry
-				.For<IAnalysisRepository>()
-				.LifecycleIs(new SingletonLifecycle())
-				.Use<AnalysisRepository>();
+			services.AddSingleton<IAnalysisRepository>(sp => new AnalysisRepository(
+				sp.GetRequiredService<ICmObjectRepository>(),
+				sp.GetRequiredService<IWfiWordformRepository>(),
+				sp.GetRequiredService<IPunctuationFormRepository>(),
+				sp.GetRequiredService<IWfiAnalysisRepository>(),
+				sp.GetRequiredService<IWfiGlossRepository>()));
 
 			// Add ReferenceAdjusterService
-			registry
-				.For<IReferenceAdjuster>()
-				.LifecycleIs(new SingletonLifecycle())
-				.Use<ReferenceAdjusterService>();
+			services.AddSingleton<IReferenceAdjuster>(sp => new ReferenceAdjusterService());
 
 			// Add SDA
-			registry
-				.For<ISilDataAccessManaged>()
-				.LifecycleIs(new SingletonLifecycle())
-				.Use<DomainDataByFlid>();
+			services.AddSingleton<ISilDataAccessManaged>(sp => new DomainDataByFlid(
+				sp.GetRequiredService<ICmObjectRepository>(),
+				sp.GetRequiredService<IStTextRepository>(),
+				sp.GetRequiredService<IFwMetaDataCacheManaged>(),
+				sp.GetRequiredService<ISilDataAccessHelperInternal>(),
+				sp.GetRequiredService<ILgWritingSystemFactory>()));
 
 			// Add loader helper
-			registry
-				.For<LoadingServices>()
-				.LifecycleIs(new SingletonLifecycle())
-				.Use<LoadingServices>();
+			services.AddSingleton<LoadingServices>(sp => new LoadingServices(
+				sp.GetRequiredService<IDataSetup>(),
+				sp.GetRequiredService<ICmObjectIdFactory>(),
+				sp.GetRequiredService<IFwMetaDataCacheManaged>(),
+				sp.GetRequiredService<ILgWritingSystemFactory>(),
+				sp.GetRequiredService<IUnitOfWorkService>(),
+				sp.GetRequiredService<ICmObjectSurrogateRepository>(),
+				sp.GetRequiredService<ICmObjectRepository>()));
+
+			// StTxtParaBldr is a stateful builder resolved by its concrete type. StructureMap
+			// auto-built it per request; register it transient to preserve that behavior.
+			services.AddTransient<StTxtParaBldr>(sp =>
+				new StTxtParaBldr(sp.GetRequiredService<LcmCache>()));
 
 			// Add writing system manager
-			registry
-				.For<WritingSystemManager>()
-				.LifecycleIs(new SingletonLifecycle())
-				.Use(() => new WritingSystemManager {TemplateFolder = m_dirs.TemplateDirectory});
-			registry
-				.For<ILgWritingSystemFactory>()
-				.Use(c => (ILgWritingSystemFactory)c.GetInstance<WritingSystemManager>());
+			services.AddSingleton<WritingSystemManager>(sp =>
+				new WritingSystemManager {TemplateFolder = m_dirs.TemplateDirectory});
+			services.AddTransient<ILgWritingSystemFactory>(sp =>
+				(ILgWritingSystemFactory)sp.GetRequiredService<WritingSystemManager>());
 
-			registry
-				.For<IWritingSystemContainer>()
-				.Use(c => c.GetInstance<ILangProjectRepository>().Singleton);
+			services.AddTransient<IWritingSystemContainer>(sp =>
+				sp.GetRequiredService<ILangProjectRepository>().Singleton);
 
-			registry
-				.For<ILcmUI>()
-				.Use(m_ui);
+			services.AddSingleton<ILcmUI>(m_ui);
 
-			registry
-				.For<ILcmDirectories>()
-				.Use(m_dirs);
+			services.AddSingleton<ILcmDirectories>(m_dirs);
 
-			registry
-				.For<LcmSettings>()
-				.Use(m_settings);
+			services.AddSingleton<LcmSettings>(m_settings);
 
 			// =================================================================================
-			// Don't add COM object to the registry. StructureMap does not properly release COM
-			// objects when the container is disposed, it will crash when the container is
-			// disposed.
+			// Don't add COM objects to the container. The container does not properly release
+			// COM objects when it is disposed; it will crash when the container is disposed.
 			// =================================================================================
 
-			var container = new Container(registry);
-			// Do this once after something is added, to make sure
-			// the entire set of objects can be created.
-			// After it proves ok, then block the line again,
-			// and let SM create them 'on demand'.
-			//container.AssertConfigurationIsValid();
+			var serviceProvider = services.BuildServiceProvider();
 
-			return new StructureMapServiceLocator(container);
+			return new MediServiceLocator(serviceProvider);
 		}
 	}
 
 	/// <summary>
-	/// Implementation of StructureMapServiceLocator, with extra methods of ILcmServiceLocator.
+	/// Service locator backed by Microsoft.Extensions.DependencyInjection, exposing the extra
+	/// methods of ILcmServiceLocator. It continues to implement CommonServiceLocator's
+	/// <see cref="ServiceLocatorImplBase"/> so downstream code that binds GetInstance&lt;T&gt;
+	/// to the interface method keeps working, source- and binary-compatible.
 	/// </summary>
-	/// <remarks>This class used to be named StructureMapServiceLocatorWrapper, wrapping a class
-	/// StructureMapServiceLocator implemented in StructureMapAdapter.dll. However, no one
-	/// could remember where that originally came from, and it implements only two simple methods
-	/// so that it seemed worth to remove the dll and implement the methods in here.</remarks>
-	internal sealed class StructureMapServiceLocator : ServiceLocatorImplBase,
+	internal sealed class MediServiceLocator : ServiceLocatorImplBase,
 		ILcmServiceLocator, IServiceLocatorInternal, IDisposable
 	{
-		private Container m_container;
+		private ServiceProvider m_serviceProvider;
 
 		/// <summary>
 		/// Constructor
 		/// </summary>
-		internal StructureMapServiceLocator(Container container)
+		internal MediServiceLocator(ServiceProvider serviceProvider)
 		{
-			m_container = container;
+			m_serviceProvider = serviceProvider;
 		}
 
 		#region Disposable stuff
 		#if DEBUG
 		/// <summary/>
-		~StructureMapServiceLocator()
+		~MediServiceLocator()
 		{
 			Dispose(false);
 		}
@@ -314,21 +295,21 @@ namespace SIL.LCModel.IOC
 			if (fDisposing && !IsDisposed)
 			{
 				// dispose managed and unmanaged objects
-				if(m_container != null)
+				if (m_serviceProvider != null)
 				{
 					try
 					{
-						m_container.Dispose();
+						m_serviceProvider.Dispose();
 					}
-					catch(InvalidComObjectException e) // Intermittantly the dispose of the container fails because a COM object has become invalid
+					catch (InvalidComObjectException e) // Intermittantly the dispose of the container fails because a COM object has become invalid
 					{
 						// Display an indication of the failure, but don't crash, we made a good faith effort to dispose all our COM objects
 						// and they probably were disposed. Also at this point we are probably shutting down, or wrapping up a unit test.
-						Debug.WriteLine(String.Format(@"COM problem when disposing container in StructureMapServiceLocator: {0}", e.Message));
+						Debug.WriteLine(String.Format(@"COM problem when disposing container in MediServiceLocator: {0}", e.Message));
 					}
 				}
 			}
-			m_container = null;
+			m_serviceProvider = null;
 			IsDisposed = true;
 		}
 		#endregion
@@ -338,18 +319,16 @@ namespace SIL.LCModel.IOC
 		///             When implemented by inheriting classes, this method will do the actual work of resolving
 		///             the requested service instance.
 		/// </summary>
-		/// <param name="serviceType">Type of instance requested.</param>B
+		/// <param name="serviceType">Type of instance requested.</param>
 		/// <param name="key">Name of registered service you want. May be null.</param>
 		/// <returns>
 		/// The requested service instance.
 		/// </returns>
 		protected override object DoGetInstance(Type serviceType, string key)
 		{
-			if (string.IsNullOrEmpty(key))
-			{
-				return m_container.GetInstance(serviceType);
-			}
-			return m_container.GetInstance(serviceType, key);
+			// LCM does not use named instances; resolve strictly by type. GetRequiredService
+			// preserves the throw-on-missing semantics of the previous StructureMap container.
+			return m_serviceProvider.GetRequiredService(serviceType);
 		}
 
 		/// <summary>
@@ -362,7 +341,11 @@ namespace SIL.LCModel.IOC
 		/// </returns>
 		protected override IEnumerable<object> DoGetAllInstances(Type serviceType)
 		{
-			foreach (object obj in m_container.GetAllInstances(serviceType))
+			var enumerableType = typeof(IEnumerable<>).MakeGenericType(serviceType);
+			var instances = (IEnumerable<object>)m_serviceProvider.GetService(enumerableType);
+			if (instances == null)
+				yield break;
+			foreach (object obj in instances)
 			{
 				yield return obj;
 			}

--- a/src/SIL.LCModel/IOC/LcmServiceLocatorFactory.cs
+++ b/src/SIL.LCModel/IOC/LcmServiceLocatorFactory.cs
@@ -126,7 +126,6 @@ namespace SIL.LCModel.IOC
 			services.AddTransient<IDataStorer>(sp => (IDataStorer)sp.GetRequiredService<IDataSetup>());
 			services.AddTransient<IDataReader>(sp => (IDataReader)sp.GetRequiredService<IDataSetup>());
 
-			// Add Mediator
 			services.AddSingleton<IUnitOfWorkService, UnitOfWorkService>();
 			// Register additional interfaces for the UnitOfWorkService.
 			services.AddTransient<ISilDataAccessHelperInternal>(sp =>
@@ -187,7 +186,7 @@ namespace SIL.LCModel.IOC
 
 			var serviceProvider = services.BuildServiceProvider();
 
-			return new MediServiceLocator(serviceProvider);
+			return new MicrosoftServiceLocator(serviceProvider);
 		}
 	}
 
@@ -197,7 +196,7 @@ namespace SIL.LCModel.IOC
 	/// <see cref="ServiceLocatorImplBase"/> so downstream code that binds GetInstance&lt;T&gt;
 	/// to the interface method keeps working, source- and binary-compatible.
 	/// </summary>
-	internal sealed class MediServiceLocator : ServiceLocatorImplBase,
+	internal sealed class MicrosoftServiceLocator : ServiceLocatorImplBase,
 		ILcmServiceLocator, IServiceLocatorInternal, IDisposable
 	{
 		private ServiceProvider m_serviceProvider;
@@ -205,7 +204,7 @@ namespace SIL.LCModel.IOC
 		/// <summary>
 		/// Constructor
 		/// </summary>
-		internal MediServiceLocator(ServiceProvider serviceProvider)
+		internal MicrosoftServiceLocator(ServiceProvider serviceProvider)
 		{
 			m_serviceProvider = serviceProvider;
 		}
@@ -213,7 +212,7 @@ namespace SIL.LCModel.IOC
 		#region Disposable stuff
 		#if DEBUG
 		/// <summary/>
-		~MediServiceLocator()
+		~MicrosoftServiceLocator()
 		{
 			Dispose(false);
 		}

--- a/src/SIL.LCModel/IOC/LcmServiceLocatorFactory.cs
+++ b/src/SIL.LCModel/IOC/LcmServiceLocatorFactory.cs
@@ -102,12 +102,10 @@ namespace SIL.LCModel.IOC
 				(ICmObjectRepositoryInternal)sp.GetRequiredService<ICmObjectRepository>());
 
 			// Add surrogate factory (internal);
-			services.AddSingleton<ICmObjectSurrogateFactory>(sp =>
-				new CmObjectSurrogateFactory(sp.GetRequiredService<LcmCache>()));
+			services.AddSingleton<ICmObjectSurrogateFactory, CmObjectSurrogateFactory>();
 
 			// Add surrogate repository (internal);
-			services.AddSingleton<ICmObjectSurrogateRepository>(sp =>
-				new CmObjectSurrogateRepository(sp.GetRequiredService<IdentityMap>()));
+			services.AddSingleton<ICmObjectSurrogateRepository, CmObjectSurrogateRepository>();
 
 			// Add BEP.
 			switch (m_backendProviderType)

--- a/src/SIL.LCModel/IOC/LcmServiceLocatorFactory.cs
+++ b/src/SIL.LCModel/IOC/LcmServiceLocatorFactory.cs
@@ -291,7 +291,8 @@ namespace SIL.LCModel.IOC
 		protected override IEnumerable<object> DoGetAllInstances(Type serviceType)
 		{
 			var enumerableType = typeof(IEnumerable<>).MakeGenericType(serviceType);
-			var instances = (IEnumerable<object>?)m_serviceProvider.GetServices(enumerableType);
+            //not using GetServices because it will throw an exception if the service is not found.
+			var instances = (IEnumerable<object>?)m_serviceProvider.GetService(enumerableType);
 			return instances ?? Enumerable.Empty<object>();
 		}
 

--- a/src/SIL.LCModel/IOC/LcmServiceLocatorFactory.cs
+++ b/src/SIL.LCModel/IOC/LcmServiceLocatorFactory.cs
@@ -6,6 +6,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
+using System.Linq;
 using System.Runtime.InteropServices;
 using CommonServiceLocator;
 using Microsoft.Extensions.DependencyInjection;
@@ -18,7 +19,6 @@ using SIL.LCModel.DomainServices;
 using SIL.LCModel.DomainServices.DataMigration;
 using SIL.LCModel.Infrastructure;
 using SIL.LCModel.Infrastructure.Impl;
-using SIL.Reporting;
 
 namespace SIL.LCModel.IOC
 {
@@ -81,8 +81,7 @@ namespace SIL.LCModel.IOC
 			services.AddSingleton<LcmCache>(sp => new LcmCache());
 
 			// Add IParagraphCounterRepository
-			services.AddSingleton<IParagraphCounterRepository>(sp =>
-				new ParagraphCounterRepository(sp.GetRequiredService<LcmCache>()));
+			services.AddSingleton<IParagraphCounterRepository, ParagraphCounterRepository>();
 
 			// Add MDC
 			services.AddSingleton<IFwMetaDataCacheManaged>(sp => new LcmMetaDataCache());
@@ -95,8 +94,7 @@ namespace SIL.LCModel.IOC
 				new Virtuals(sp.GetRequiredService<IFwMetaDataCacheManaged>()));
 
 			// Add IdentityMap
-			services.AddSingleton<IdentityMap>(sp =>
-				new IdentityMap(sp.GetRequiredService<IFwMetaDataCacheManaged>()));
+			services.AddSingleton<IdentityMap>();
 			// Register IdentityMap's other interface.
 			services.AddTransient<ICmObjectIdFactory>(sp =>
 				(ICmObjectIdFactory)sp.GetRequiredService<IdentityMap>());
@@ -117,37 +115,13 @@ namespace SIL.LCModel.IOC
 				default:
 					throw new InvalidOperationException(Strings.ksInvalidBackendProviderType);
 				case BackendProviderType.kXML:
-					services.AddSingleton<IDataSetup>(sp => new XMLBackendProvider(
-						sp.GetRequiredService<LcmCache>(),
-						sp.GetRequiredService<IdentityMap>(),
-						sp.GetRequiredService<ICmObjectSurrogateFactory>(),
-						sp.GetRequiredService<IFwMetaDataCacheManagedInternal>(),
-						sp.GetRequiredService<IDataMigrationManager>(),
-						sp.GetRequiredService<ILcmUI>(),
-						sp.GetRequiredService<ILcmDirectories>(),
-						sp.GetRequiredService<LcmSettings>()));
+					services.AddSingleton<IDataSetup, XMLBackendProvider>();
 					break;
 				case BackendProviderType.kMemoryOnly:
-					services.AddSingleton<IDataSetup>(sp => new MemoryOnlyBackendProvider(
-						sp.GetRequiredService<LcmCache>(),
-						sp.GetRequiredService<IdentityMap>(),
-						sp.GetRequiredService<ICmObjectSurrogateFactory>(),
-						sp.GetRequiredService<IFwMetaDataCacheManagedInternal>(),
-						sp.GetRequiredService<IDataMigrationManager>(),
-						sp.GetRequiredService<ILcmUI>(),
-						sp.GetRequiredService<ILcmDirectories>(),
-						sp.GetRequiredService<LcmSettings>()));
+					services.AddSingleton<IDataSetup, MemoryOnlyBackendProvider>();
 					break;
 				case BackendProviderType.kSharedXML:
-					services.AddSingleton<IDataSetup>(sp => new SharedXMLBackendProvider(
-						sp.GetRequiredService<LcmCache>(),
-						sp.GetRequiredService<IdentityMap>(),
-						sp.GetRequiredService<ICmObjectSurrogateFactory>(),
-						sp.GetRequiredService<IFwMetaDataCacheManagedInternal>(),
-						sp.GetRequiredService<IDataMigrationManager>(),
-						sp.GetRequiredService<ILcmUI>(),
-						sp.GetRequiredService<ILcmDirectories>(),
-						sp.GetRequiredService<LcmSettings>()));
+					services.AddSingleton<IDataSetup, SharedXMLBackendProvider>();
 					break;
 			}
 			// Register two additional interfaces of the BEP, which are injected into other services.
@@ -155,12 +129,7 @@ namespace SIL.LCModel.IOC
 			services.AddTransient<IDataReader>(sp => (IDataReader)sp.GetRequiredService<IDataSetup>());
 
 			// Add Mediator
-			services.AddSingleton<IUnitOfWorkService>(sp => new UnitOfWorkService(
-				sp.GetRequiredService<IDataStorer>(),
-				sp.GetRequiredService<IdentityMap>(),
-				sp.GetRequiredService<ICmObjectRepositoryInternal>(),
-				sp.GetRequiredService<ILcmUI>(),
-				logger));
+			services.AddSingleton<IUnitOfWorkService, UnitOfWorkService>();
 			// Register additional interfaces for the UnitOfWorkService.
 			services.AddTransient<ISilDataAccessHelperInternal>(sp =>
 				(ISilDataAccessHelperInternal)sp.GetRequiredService<IUnitOfWorkService>());
@@ -183,38 +152,20 @@ namespace SIL.LCModel.IOC
 			AddRepositories(services);
 
 			// Add IAnalysisRepository
-			services.AddSingleton<IAnalysisRepository>(sp => new AnalysisRepository(
-				sp.GetRequiredService<ICmObjectRepository>(),
-				sp.GetRequiredService<IWfiWordformRepository>(),
-				sp.GetRequiredService<IPunctuationFormRepository>(),
-				sp.GetRequiredService<IWfiAnalysisRepository>(),
-				sp.GetRequiredService<IWfiGlossRepository>()));
+			services.AddSingleton<IAnalysisRepository, AnalysisRepository>();
 
 			// Add ReferenceAdjusterService
 			services.AddSingleton<IReferenceAdjuster>(sp => new ReferenceAdjusterService());
 
 			// Add SDA
-			services.AddSingleton<ISilDataAccessManaged>(sp => new DomainDataByFlid(
-				sp.GetRequiredService<ICmObjectRepository>(),
-				sp.GetRequiredService<IStTextRepository>(),
-				sp.GetRequiredService<IFwMetaDataCacheManaged>(),
-				sp.GetRequiredService<ISilDataAccessHelperInternal>(),
-				sp.GetRequiredService<ILgWritingSystemFactory>()));
+			services.AddSingleton<ISilDataAccessManaged, DomainDataByFlid>();
 
 			// Add loader helper
-			services.AddSingleton<LoadingServices>(sp => new LoadingServices(
-				sp.GetRequiredService<IDataSetup>(),
-				sp.GetRequiredService<ICmObjectIdFactory>(),
-				sp.GetRequiredService<IFwMetaDataCacheManaged>(),
-				sp.GetRequiredService<ILgWritingSystemFactory>(),
-				sp.GetRequiredService<IUnitOfWorkService>(),
-				sp.GetRequiredService<ICmObjectSurrogateRepository>(),
-				sp.GetRequiredService<ICmObjectRepository>()));
+			services.AddSingleton<LoadingServices>();
 
 			// StTxtParaBldr is a stateful builder resolved by its concrete type. StructureMap
 			// auto-built it per request; register it transient to preserve that behavior.
-			services.AddTransient<StTxtParaBldr>(sp =>
-				new StTxtParaBldr(sp.GetRequiredService<LcmCache>()));
+			services.AddTransient<StTxtParaBldr>();
 
 			// Add writing system manager
 			services.AddSingleton<WritingSystemManager>(sp =>
@@ -342,13 +293,8 @@ namespace SIL.LCModel.IOC
 		protected override IEnumerable<object> DoGetAllInstances(Type serviceType)
 		{
 			var enumerableType = typeof(IEnumerable<>).MakeGenericType(serviceType);
-			var instances = (IEnumerable<object>)m_serviceProvider.GetService(enumerableType);
-			if (instances == null)
-				yield break;
-			foreach (object obj in instances)
-			{
-				yield return obj;
-			}
+			var instances = (IEnumerable<object>?)m_serviceProvider.GetServices(enumerableType);
+			return instances ?? Enumerable.Empty<object>();
 		}
 
 		#endregion

--- a/src/SIL.LCModel/Infrastructure/Impl/CmObjectIdentityMap.cs
+++ b/src/SIL.LCModel/Infrastructure/Impl/CmObjectIdentityMap.cs
@@ -55,7 +55,7 @@ namespace SIL.LCModel.Infrastructure.Impl
 		/// <summary>
 		/// Constructor
 		/// </summary>
-		internal IdentityMap(IFwMetaDataCacheManaged mdc)
+		public IdentityMap(IFwMetaDataCacheManaged mdc)
 		{
 			if (mdc == null) throw new ArgumentNullException("mdc");
 

--- a/src/SIL.LCModel/Infrastructure/Impl/CmObjectIdentityMap.cs
+++ b/src/SIL.LCModel/Infrastructure/Impl/CmObjectIdentityMap.cs
@@ -82,8 +82,8 @@ namespace SIL.LCModel.Infrastructure.Impl
 
 		/// ------------------------------------------------------------------------------------
 		/// <summary>
-		/// Releases the memory stored in the IdentityMap. This is called automatically from
-		/// StructureMap when the StructureMap container is disposed.
+		/// Releases the memory stored in the IdentityMap. This is called automatically by the
+		/// DI container when the container is disposed.
 		/// </summary>
 		/// ------------------------------------------------------------------------------------
 		public void Dispose()

--- a/src/SIL.LCModel/Infrastructure/Impl/CmObjectSurrogate.cs
+++ b/src/SIL.LCModel/Infrastructure/Impl/CmObjectSurrogate.cs
@@ -755,7 +755,7 @@ namespace SIL.LCModel.Infrastructure.Impl
 		/// Constructor
 		/// </summary>
 		/// <param name="identityMap"></param>
-		internal CmObjectSurrogateRepository(IdentityMap identityMap)
+		public CmObjectSurrogateRepository(IdentityMap identityMap)
 		{
 			if (identityMap == null) throw new ArgumentNullException("identityMap");
 			m_identityMap = identityMap;
@@ -797,7 +797,7 @@ namespace SIL.LCModel.Infrastructure.Impl
 		/// <summary>
 		/// Constructor.
 		/// </summary>
-		internal CmObjectSurrogateFactory(LcmCache cache)
+		public CmObjectSurrogateFactory(LcmCache cache)
 		{
 			if (cache == null) throw new ArgumentNullException("cache");
 

--- a/src/SIL.LCModel/Infrastructure/Impl/MemoryOnlyBackendProvider.cs
+++ b/src/SIL.LCModel/Infrastructure/Impl/MemoryOnlyBackendProvider.cs
@@ -20,7 +20,7 @@ namespace SIL.LCModel.Infrastructure.Impl
 		/// <summary>
 		/// Constructor.
 		/// </summary>
-		internal MemoryOnlyBackendProvider(LcmCache cache, IdentityMap identityMap, ICmObjectSurrogateFactory surrogateFactory,
+		public MemoryOnlyBackendProvider(LcmCache cache, IdentityMap identityMap, ICmObjectSurrogateFactory surrogateFactory,
 			IFwMetaDataCacheManagedInternal mdc, IDataMigrationManager dataMigrationManager, ILcmUI ui, ILcmDirectories dirs, LcmSettings settings)
 			: base(cache, identityMap, surrogateFactory, mdc, dataMigrationManager, ui, dirs, settings)
 		{

--- a/src/SIL.LCModel/Infrastructure/Impl/PargraphCounterRepository.cs
+++ b/src/SIL.LCModel/Infrastructure/Impl/PargraphCounterRepository.cs
@@ -28,7 +28,7 @@ namespace SIL.LCModel.Infrastructure.Impl
 		/// </summary>
 		/// <param name="cache">The cache.</param>
 		/// ------------------------------------------------------------------------------------
-		internal ParagraphCounterRepository(LcmCache cache)
+		public ParagraphCounterRepository(LcmCache cache)
 		{
 			m_cache = cache;
 		}

--- a/src/SIL.LCModel/Infrastructure/Impl/RepositoryAdditions.cs
+++ b/src/SIL.LCModel/Infrastructure/Impl/RepositoryAdditions.cs
@@ -44,7 +44,7 @@ namespace SIL.LCModel.Infrastructure.Impl
 		/// <summary>
 		/// Constructor
 		/// </summary>
-		internal AnalysisRepository(ICmObjectRepository everythingRepos, IWfiWordformRepository wordformRepos,
+		public AnalysisRepository(ICmObjectRepository everythingRepos, IWfiWordformRepository wordformRepos,
 			IPunctuationFormRepository punctFormRepos, IWfiAnalysisRepository analysisRepos, IWfiGlossRepository glossRepos)
 		{
 			if (everythingRepos == null) throw new ArgumentNullException("everythingRepos");

--- a/src/SIL.LCModel/Infrastructure/Impl/SharedXMLBackendProvider.cs
+++ b/src/SIL.LCModel/Infrastructure/Impl/SharedXMLBackendProvider.cs
@@ -38,7 +38,7 @@ namespace SIL.LCModel.Infrastructure.Impl
 		private readonly Dictionary<int, Process> m_peerProcesses;
 		private string m_commitLogDir;
 
-		internal SharedXMLBackendProvider(LcmCache cache, IdentityMap identityMap, ICmObjectSurrogateFactory surrogateFactory, IFwMetaDataCacheManagedInternal mdc,
+		public SharedXMLBackendProvider(LcmCache cache, IdentityMap identityMap, ICmObjectSurrogateFactory surrogateFactory, IFwMetaDataCacheManagedInternal mdc,
 			IDataMigrationManager dataMigrationManager, ILcmUI ui, ILcmDirectories dirs, LcmSettings settings)
 			: base(cache, identityMap, surrogateFactory, mdc, dataMigrationManager, ui, dirs, settings)
 		{

--- a/src/SIL.LCModel/Infrastructure/Impl/UnitOfWorkService.cs
+++ b/src/SIL.LCModel/Infrastructure/Impl/UnitOfWorkService.cs
@@ -153,7 +153,7 @@ namespace SIL.LCModel.Infrastructure.Impl
 		/// <summary>
 		/// Constructor.
 		/// </summary>
-		public UnitOfWorkService(IDataStorer dataStorer, IdentityMap identityMap, ICmObjectRepositoryInternal objectRepository, ILcmUI ui, ITransactionLogger logger)
+		public UnitOfWorkService(IDataStorer dataStorer, IdentityMap identityMap, ICmObjectRepositoryInternal objectRepository, ILcmUI ui, ITransactionLogger? logger = null)
 		{
 			if (dataStorer == null) throw new ArgumentNullException("dataStorer");
 			if (identityMap == null) throw new ArgumentNullException("identityMap");

--- a/src/SIL.LCModel/Infrastructure/Impl/UnitOfWorkService.cs
+++ b/src/SIL.LCModel/Infrastructure/Impl/UnitOfWorkService.cs
@@ -153,7 +153,7 @@ namespace SIL.LCModel.Infrastructure.Impl
 		/// <summary>
 		/// Constructor.
 		/// </summary>
-		internal UnitOfWorkService(IDataStorer dataStorer, IdentityMap identityMap, ICmObjectRepositoryInternal objectRepository, ILcmUI ui, ITransactionLogger logger)
+		public UnitOfWorkService(IDataStorer dataStorer, IdentityMap identityMap, ICmObjectRepositoryInternal objectRepository, ILcmUI ui, ITransactionLogger logger)
 		{
 			if (dataStorer == null) throw new ArgumentNullException("dataStorer");
 			if (identityMap == null) throw new ArgumentNullException("identityMap");

--- a/src/SIL.LCModel/Infrastructure/Impl/XMLBackendProvider.cs
+++ b/src/SIL.LCModel/Infrastructure/Impl/XMLBackendProvider.cs
@@ -121,7 +121,7 @@ namespace SIL.LCModel.Infrastructure.Impl
 		/// <summary>
 		/// Constructor.
 		/// </summary>
-		internal XMLBackendProvider(LcmCache cache, IdentityMap identityMap,
+		public XMLBackendProvider(LcmCache cache, IdentityMap identityMap,
 			ICmObjectSurrogateFactory surrogateFactory, IFwMetaDataCacheManagedInternal mdc,
 			IDataMigrationManager dataMigrationManager, ILcmUI ui, ILcmDirectories dirs, LcmSettings settings) :
 			base(cache, identityMap, surrogateFactory, mdc, dataMigrationManager, ui, dirs, settings)

--- a/src/SIL.LCModel/Infrastructure/XmlServices.cs
+++ b/src/SIL.LCModel/Infrastructure/XmlServices.cs
@@ -168,7 +168,7 @@ namespace SIL.LCModel.Infrastructure
 		/// <summary>
 		/// Constructor
 		/// </summary>
-		internal LoadingServices(IDataSetup dataSetup, ICmObjectIdFactory objIdFactory,
+		public LoadingServices(IDataSetup dataSetup, ICmObjectIdFactory objIdFactory,
 			IFwMetaDataCacheManaged mdcManaged, ILgWritingSystemFactory wsf, IUnitOfWorkService uowService,
 			ICmObjectSurrogateRepository surrRepository, ICmObjectRepository cmObjRepository)
 		{

--- a/src/SIL.LCModel/LcmCacheIDisposableInterfaceImpl.cs
+++ b/src/SIL.LCModel/LcmCacheIDisposableInterfaceImpl.cs
@@ -3,7 +3,6 @@
 // (http://www.gnu.org/licenses/lgpl-2.1.html)
 
 using System;
-using SIL.LCModel.IOC;
 
 namespace SIL.LCModel
 {
@@ -128,9 +127,9 @@ namespace SIL.LCModel
 				// NOTE: this needs to be last since it calls LcmCache.Dispose() which
 				// sets all member variables to null.
 				// This will also dispose all Singletons which includes m_serviceLocator.GetInstance<IDataSetup>()
-				var serviceLocatorWrapper = m_serviceLocator as StructureMapServiceLocator;
-				if (serviceLocatorWrapper != null)
-					serviceLocatorWrapper.Dispose();
+				var disposableServiceLocator = m_serviceLocator as IDisposable;
+				if (disposableServiceLocator != null)
+					disposableServiceLocator.Dispose();
 			}
 
 			// Dispose unmanaged resources here, whether disposing is true or false.

--- a/src/SIL.LCModel/LcmGenerate/LcmServiceLocatorBootstrapper.vm.cs
+++ b/src/SIL.LCModel/LcmGenerate/LcmServiceLocatorBootstrapper.vm.cs
@@ -7,10 +7,10 @@
 ## This file is used by the LcmGenerate task to generate the source code from the XMI
 ## database model.
 ## --------------------------------------------------------------------------------------------
+using Microsoft.Extensions.DependencyInjection;
 using SIL.LCModel.DomainImpl;
+using SIL.LCModel.Infrastructure;
 using SIL.LCModel.Infrastructure.Impl;
-using StructureMap;
-using StructureMap.Pipeline;
 
 namespace SIL.LCModel.IOC
 {
@@ -19,7 +19,11 @@ namespace SIL.LCModel.IOC
 	/// </summary>
 	internal partial class LcmServiceLocatorFactory
 	{
-		private static void AddFactories(Registry registry)
+		// Each type is registered by its concrete type (the actual singleton) with the
+		// interface registered as an alias resolving to that same singleton. This mirrors the
+		// previous StructureMap container, which allowed resolving a registered service by
+		// either its interface or its concrete implementation type.
+		private static void AddFactories(IServiceCollection services)
 		{
 #foreach($module in $lcmgenerate.Modules)
 #foreach($class in $module.Classes)
@@ -29,23 +33,20 @@ namespace SIL.LCModel.IOC
 #set( $classSfx = "Factory" )
 #end
 #if(!$class.IsAbstract)
-			registry
-				.For<I${class.Name}$classSfx>()
-				.LifecycleIs(new SingletonLifecycle())
-				.Use<${class.Name}$classSfx>();
+			services.AddSingleton<${class.Name}$classSfx>(sp => new ${class.Name}$classSfx(sp.GetRequiredService<LcmCache>()));
+			services.AddSingleton<I${class.Name}$classSfx>(sp => sp.GetRequiredService<${class.Name}$classSfx>());
 #end
 #end
 #end
 		}
 
-		private static void AddRepositories(Registry registry)
+		private static void AddRepositories(IServiceCollection services)
 		{
 #foreach($module in $lcmgenerate.Modules)
 #foreach($class in $module.Classes)
-			registry
-				.For<I${class.Name}Repository>()
-				.LifecycleIs(new SingletonLifecycle())
-				.Use<${class.Name}Repository>();
+			services.AddSingleton<${class.Name}Repository>(sp => new ${class.Name}Repository(
+				sp.GetRequiredService<LcmCache>(), sp.GetRequiredService<IDataReader>()));
+			services.AddSingleton<I${class.Name}Repository>(sp => sp.GetRequiredService<${class.Name}Repository>());
 #end
 #end
 		}

--- a/src/SIL.LCModel/SIL.LCModel.csproj
+++ b/src/SIL.LCModel/SIL.LCModel.csproj
@@ -18,6 +18,7 @@
 
   <ItemGroup>
     <PackageReference Include="CommonServiceLocator" Version="2.0.7" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.1" />
     <PackageReference Include="GitVersion.MsBuild" Version="5.6.10" PrivateAssets="All" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
     <PackageReference Include="protobuf-net" Version="2.4.6" />
@@ -26,7 +27,6 @@
     <PackageReference Include="SIL.Lexicon" Version="17.0.0-*" />
     <PackageReference Include="SIL.ReleaseTasks" Version="2.5.0" PrivateAssets="All" />
     <PackageReference Include="SIL.WritingSystems" Version="17.0.0-*" />
-    <PackageReference Include="structuremap.patched" Version="4.7.3" />
     <PackageReference Include="System.ServiceProcess.ServiceController" Version="6.0.0" />
     <PackageReference Include="Nullable" Version="1.3.1">
       <PrivateAssets>all</PrivateAssets>

--- a/tests/SIL.LCModel.Tests/DomainServices/PhonologyServicesTest.cs
+++ b/tests/SIL.LCModel.Tests/DomainServices/PhonologyServicesTest.cs
@@ -6,7 +6,6 @@ using SIL.LCModel.Core.WritingSystems;
 using SIL.LCModel.Infrastructure;
 using System.IO;
 using SIL.LCModel.Core.KernelInterfaces;
-using StructureMap.Diagnostics.TreeView;
 using SIL.LCModel.Core.Text;
 using System.Xml.Linq;
 using System.Security.Cryptography;

--- a/tests/SIL.LCModel.Tests/Infrastructure/LcmServiceLocatorTests.cs
+++ b/tests/SIL.LCModel.Tests/Infrastructure/LcmServiceLocatorTests.cs
@@ -14,9 +14,7 @@ namespace SIL.LCModel.Infrastructure
 	[TestFixture]
 	public class LcmServiceLocatorTests : MemoryOnlyBackendProviderTestBase
 	{
-		/// <summary>
-		/// Verify that core services resolve and shortcut properties match GetInstance.
-		/// </summary>
+		/// <summary/>
 		[Test]
 		public void SmokeTest_ResolvesCoreServices()
 		{
@@ -33,9 +31,7 @@ namespace SIL.LCModel.Infrastructure
 			Assert.That(sl.ActionHandler, Is.SameAs(sl.GetInstance<IActionHandler>()));
 		}
 
-		/// <summary>
-		/// GetAllInstances returns registered services and an empty sequence for unknown types.
-		/// </summary>
+		/// <summary/>
 		[Test]
 		public void GetAllInstances_ReturnsRegisteredServices()
 		{
@@ -44,9 +40,8 @@ namespace SIL.LCModel.Infrastructure
 			Assert.That(instances[0], Is.SameAs(Cache.ServiceLocator.GetInstance<IDataSetup>()));
 		}
 
-		/// <summary>
-		/// GetAllInstances returns an empty sequence when the type is not registered.
-		/// </summary>
+
+		/// <summary/>
 		[Test]
 		public void GetAllInstances_ReturnsEmptyForUnregisteredType()
 		{

--- a/tests/SIL.LCModel.Tests/Infrastructure/LcmServiceLocatorTests.cs
+++ b/tests/SIL.LCModel.Tests/Infrastructure/LcmServiceLocatorTests.cs
@@ -1,0 +1,59 @@
+// Copyright (c) 2026 SIL International
+// This software is licensed under the LGPL, version 2.1 or later
+// (http://www.gnu.org/licenses/lgpl-2.1.html)
+
+using System.Linq;
+using NUnit.Framework;
+using SIL.LCModel.Core.KernelInterfaces;
+
+namespace SIL.LCModel.Infrastructure
+{
+	/// <summary>
+	/// Smoke tests for the LCM service locator wiring.
+	/// </summary>
+	[TestFixture]
+	public class LcmServiceLocatorTests : MemoryOnlyBackendProviderTestBase
+	{
+		/// <summary>
+		/// Verify that core services resolve and shortcut properties match GetInstance.
+		/// </summary>
+		[Test]
+		public void SmokeTest_ResolvesCoreServices()
+		{
+			var sl = Cache.ServiceLocator;
+			Assert.That(sl, Is.Not.Null);
+
+			Assert.That(sl.GetInstance<IDataSetup>(), Is.Not.Null);
+			Assert.That(sl.GetInstance<ICmObjectRepository>(), Is.Not.Null);
+			Assert.That(sl.GetInstance<IFwMetaDataCacheManaged>(), Is.Not.Null);
+
+			Assert.That(sl.DataSetup, Is.SameAs(sl.GetInstance<IDataSetup>()));
+			Assert.That(sl.ObjectRepository, Is.SameAs(sl.GetInstance<ICmObjectRepository>()));
+			Assert.That(sl.MetaDataCache, Is.SameAs(sl.GetInstance<IFwMetaDataCacheManaged>()));
+			Assert.That(sl.ActionHandler, Is.SameAs(sl.GetInstance<IActionHandler>()));
+		}
+
+		/// <summary>
+		/// GetAllInstances returns registered services and an empty sequence for unknown types.
+		/// </summary>
+		[Test]
+		public void GetAllInstances_ReturnsRegisteredServices()
+		{
+			var instances = Cache.ServiceLocator.GetAllInstances<IDataSetup>().ToList();
+			Assert.That(instances, Is.Not.Empty);
+			Assert.That(instances[0], Is.SameAs(Cache.ServiceLocator.GetInstance<IDataSetup>()));
+		}
+
+		/// <summary>
+		/// GetAllInstances returns an empty sequence when the type is not registered.
+		/// </summary>
+		[Test]
+		public void GetAllInstances_ReturnsEmptyForUnregisteredType()
+		{
+			var instances = Cache.ServiceLocator.GetAllInstances<IUnregisteredForServiceLocatorTest>().ToList();
+			Assert.That(instances, Is.Empty);
+		}
+
+		private interface IUnregisteredForServiceLocatorTest { }
+	}
+}


### PR DESCRIPTION
- Swap `structuremap.patched` for `Microsoft.Extensions.DependencyInjection` 8.x
- Rename `StructureMapServiceLocator` → `MediServiceLocator`; no public API change
- Use explicit factory lambdas for all registrations (compile-time checked)
- Dispose service locator via `IDisposable` instead of concrete type cast
- Some internal constructors were changed to public, only when the type itself was internal. The Microsoft IoC container will not use internal constructors, only public. This should have not effect on consumers as the type itself is still internal. For any public types with an internal constructor those were not changed and the registration was changed to construct it in line.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/liblcm/393)
<!-- Reviewable:end -->
