### PR TITLE
Fix LibLCM .NET 8 CI builds

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,5 +1,6 @@
 {
 	"sdk": {
-		"rollForward": "latestMajor"
+		"version": "8.0.100",
+		"rollForward": "latestFeature"
 	}
 }

--- a/src/SIL.LCModel/SIL.LCModel.csproj
+++ b/src/SIL.LCModel/SIL.LCModel.csproj
@@ -89,7 +89,6 @@
   </ItemGroup>
 
   <PropertyGroup>
-    <OutDir Condition="'$(OutDir)' == ''">../../artifacts/$(Configuration)/$(TargetFramework)/</OutDir>
     <MsBuildCommand Condition="'$(MsBuildRuntimeType)'=='Core' And '$(MsBuildCommand)'==''">dotnet build</MsBuildCommand>
     <MsbuildCommand Condition="'$(OS)'=='Windows_NT' And '$(MsBuildCommand)'==''">"$(MSBuildBinPath)\msbuild.exe"</MsbuildCommand>
     <MsbuildCommand Condition="'$(OS)'=='Unix' And '$(MsBuildCommand)'==''">msbuild</MsbuildCommand>


### PR DESCRIPTION
## Summary

- Pin SDK selection to .NET 8 until the planned .NET 10 migration.
- Remove the redundant project-level `OutDir` override so multi-target inner builds use the per-framework `OutputPath` from `Directory.Build.props`.

## Why

The hosted Windows runner selected .NET 10 because `global.json` allowed `latestMajor`. Pinning the SDK exposed an existing multi-target output collision on both Windows and Ubuntu: a `net8.0` `SIL.LCModel.Core.dll` could be written to `artifacts/Release/netstandard2.0`, causing CS1705 when the netstandard `SIL.LCModel` target consumed it.

The project-level `OutDir` duplicated the repository-wide `OutputPath` and allowed a parent target's output directory to leak into referenced inner builds. Letting the SDK derive `OutDir` from the central `OutputPath` keeps `netstandard2.0`, `net462`, and `net8.0` outputs separate.

## Validation

- `dotnet --version`: 8.0.424
- `dotnet build LCM.sln --configuration Release`: passed with 0 errors
- Full test stage: 5,638 passed, 40 skipped, 0 failed
- `dotnet pack LCM.sln --include-symbols --no-restore --no-build -p:SymbolPackageFormat=snupkg --configuration Release`: all packages created

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/liblcm/394)
<!-- Reviewable:end -->
