### PR TITLE
Fix Windows CI by scoping IntermediateOutputPath per framework

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -14,13 +14,6 @@
     <Configuration Condition="'$(Configuration)' == ''">Debug</Configuration>
     <OutputPath>$(MSBuildThisFileDirectory)artifacts/$(Configuration)/$(TargetFramework)</OutputPath>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
-    <!-- AppendTargetFrameworkToOutputPath=false strips $(TargetFramework) from
-         IntermediateOutputPath as well as OutputPath, so every target framework of a
-         multi-targeted project would share one obj folder - and therefore one reference
-         assembly in obj/ref. Whichever framework built last won, which is how a
-         netstandard2.0 compile ended up referencing the net8.0 build of SIL.LCModel.Core
-         (CS1705, System.Drawing.Primitives 8.0.0.0). OutputPath already carries the
-         framework, so only the intermediate path needs restoring here. -->
     <IntermediateOutputPath Condition="'$(TargetFramework)' != ''">obj/$(Configuration)/$(TargetFramework)/</IntermediateOutputPath>
     <PackageOutputPath>$(MSBuildThisFileDirectory)/artifacts</PackageOutputPath>
     <WarningsAsErrors>NU1605;CS8002</WarningsAsErrors>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -14,6 +14,14 @@
     <Configuration Condition="'$(Configuration)' == ''">Debug</Configuration>
     <OutputPath>$(MSBuildThisFileDirectory)artifacts/$(Configuration)/$(TargetFramework)</OutputPath>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
+    <!-- AppendTargetFrameworkToOutputPath=false strips $(TargetFramework) from
+         IntermediateOutputPath as well as OutputPath, so every target framework of a
+         multi-targeted project would share one obj folder - and therefore one reference
+         assembly in obj/ref. Whichever framework built last won, which is how a
+         netstandard2.0 compile ended up referencing the net8.0 build of SIL.LCModel.Core
+         (CS1705, System.Drawing.Primitives 8.0.0.0). OutputPath already carries the
+         framework, so only the intermediate path needs restoring here. -->
+    <IntermediateOutputPath Condition="'$(TargetFramework)' != ''">obj/$(Configuration)/$(TargetFramework)/</IntermediateOutputPath>
     <PackageOutputPath>$(MSBuildThisFileDirectory)/artifacts</PackageOutputPath>
     <WarningsAsErrors>NU1605;CS8002</WarningsAsErrors>
     <IncludeSymbols>true</IncludeSymbols>

--- a/src/SIL.LCModel.Core/SIL.LCModel.Core.csproj
+++ b/src/SIL.LCModel.Core/SIL.LCModel.Core.csproj
@@ -86,7 +86,10 @@ SIL.LCModel.Core provides a base library with core functionality.</Description>
   </ItemGroup>
 
   <PropertyGroup>
-    <IntermediateOutputPath Condition="'$(IntermediateOutputPath)' == ''">obj/x86/$(Configuration)/</IntermediateOutputPath>
+    <!-- IntermediateOutputPath comes from Directory.Build.props, which scopes it per target
+         framework. The old obj/x86/$(Configuration)/ override here predates multi-targeting:
+         it gave all three frameworks one obj folder, and Platform is "Any CPU" repo-wide, so
+         the x86 segment bought nothing. -->
     <MsBuildCommand Condition="'$(MsBuildRuntimeType)'=='Core' And '$(MsBuildCommand)'==''">dotnet build</MsBuildCommand>
     <MsbuildCommand Condition="'$(OS)'=='Windows_NT' And '$(MsBuildCommand)'==''">"$(MSBuildBinPath)\msbuild.exe"</MsbuildCommand>
     <MsbuildCommand Condition="'$(OS)'=='Unix' And '$(MsBuildCommand)'==''">msbuild</MsbuildCommand>

--- a/src/SIL.LCModel.Core/SIL.LCModel.Core.csproj
+++ b/src/SIL.LCModel.Core/SIL.LCModel.Core.csproj
@@ -86,10 +86,6 @@ SIL.LCModel.Core provides a base library with core functionality.</Description>
   </ItemGroup>
 
   <PropertyGroup>
-    <!-- IntermediateOutputPath comes from Directory.Build.props, which scopes it per target
-         framework. The old obj/x86/$(Configuration)/ override here predates multi-targeting:
-         it gave all three frameworks one obj folder, and Platform is "Any CPU" repo-wide, so
-         the x86 segment bought nothing. -->
     <MsBuildCommand Condition="'$(MsBuildRuntimeType)'=='Core' And '$(MsBuildCommand)'==''">dotnet build</MsBuildCommand>
     <MsbuildCommand Condition="'$(OS)'=='Windows_NT' And '$(MsBuildCommand)'==''">"$(MSBuildBinPath)\msbuild.exe"</MsbuildCommand>
     <MsbuildCommand Condition="'$(OS)'=='Unix' And '$(MsBuildCommand)'==''">msbuild</MsbuildCommand>


### PR DESCRIPTION
Directory.Build.props sets AppendTargetFrameworkToOutputPath=false so that OutputPath can place output under artifacts/$(Configuration)/$(TargetFramework) itself. That flag also strips $(TargetFramework) from IntermediateOutputPath, so all three target frameworks of a multi-targeted project shared a single obj folder - including the reference assembly under obj/ref. Whichever framework built last owned it.

ProjectReference resolution reads that reference assembly, so the netstandard2.0 compile of SIL.LCModel could be handed the net8.0 build of SIL.LCModel.Core:

  CSC : error CS1705: Assembly 'SIL.LCModel.Core' ... uses
  'System.Drawing.Primitives, Version=8.0.0.0' which has a higher version than
  referenced assembly 'System.Drawing.Primitives, Version=4.0.2.0'
  [SIL.LCModel.csproj::TargetFramework=netstandard2.0]

Build ordering decided whether this hit, which is why Windows failed while Linux stayed green. #394 removed the OutDir override in SIL.LCModel and fixed the bin side of the same problem; the intermediate side kept sharing one path.

Set IntermediateOutputPath to obj/$(Configuration)/$(TargetFramework)/ in Directory.Build.props, and drop the obj/x86/$(Configuration)/ override in SIL.LCModel.Core.csproj that predates multi-targeting and now conflicts with it - Platform is Any CPU repo-wide, so the x86 segment bought nothing. OutputPath and the artifacts layout are unchanged.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/liblcm/396)
<!-- Reviewable:end -->
